### PR TITLE
fix: `cpus` length in a chroot environment (`os.cpus()`)

### DIFF
--- a/src/TaskRunner.js
+++ b/src/TaskRunner.js
@@ -19,10 +19,13 @@ export default class TaskRunner {
     const { cache, parallel } = options;
     this.cacheDir =
       cache === true ? findCacheDir({ name: 'terser-webpack-plugin' }) : cache;
+    // In some cases cpus() returns undefined
+    // https://github.com/nodejs/node/issues/19022
+    const cpus = os.cpus() || { length: 1 };
     this.maxConcurrentWorkers =
       parallel === true
-        ? os.cpus().length - 1
-        : Math.min(Number(parallel) || 0, os.cpus().length - 1);
+        ? cpus.length - 1
+        : Math.min(Number(parallel) || 0, cpus.length - 1);
   }
 
   run(tasks, callback) {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #3

### Breaking Changes

no

### Additional Info

no