### PR TITLE
feat: dedupe extracted comments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -302,18 +302,18 @@ class TerserPlugin {
           // Write extracted comments to commentsFile
           if (commentsFile && extractedComments.length > 0) {
             // Filter out duplicate comments, if commentsFile already exits
-            let filteredComments = extractedComments;
+            let dedupedComments = extractedComments;
             if (commentsFile in compilation.assets) {
               const commentsFileSource = compilation.assets[
                 commentsFile
               ].source();
 
-              filteredComments = filteredComments.filter(
-                (comment) => commentsFileSource.indexOf(comment) === -1
+              dedupedComments = dedupedComments.filter(
+                (comment) => !commentsFileSource.includes(comment)
               );
             }
 
-            if (filteredComments.length) {
+            if (dedupedComments.length > 0) {
               // Add a banner to the original file
               if (this.options.extractComments.banner !== false) {
                 let banner =
@@ -334,7 +334,7 @@ class TerserPlugin {
                 }
               }
 
-              const commentsString = `${filteredComments.join('\n\n')}\n`;
+              const commentsString = `${dedupedComments.join('\n\n')}\n`;
 
               if (commentsFile in compilation.assets) {
                 // commentsFile already exists, append new comments...

--- a/src/minify.js
+++ b/src/minify.js
@@ -127,11 +127,15 @@ const buildComments = (options, terserOptions, extractedComments) => {
   // comments according to the two conditions
   return (astNode, comment) => {
     if (condition.extract(astNode, comment)) {
-      extractedComments.push(
+      const commentTxt =
         comment.type === 'comment2'
           ? `/*${comment.value}*/`
-          : `//${comment.value}`
-      );
+          : `//${comment.value}`;
+
+      // Don't include duplicate comments
+      if (!extractedComments.includes(commentTxt)) {
+        extractedComments.push(commentTxt);
+      }
     }
 
     return condition.preserve(astNode, comment);

--- a/test/__snapshots__/extractComments-option.test.js.snap
+++ b/test/__snapshots__/extractComments-option.test.js.snap
@@ -64,13 +64,9 @@ exports[`when applied with \`extractComments\` option matches snapshot for a \`a
 exports[`when applied with \`extractComments\` option matches snapshot for a \`all\` value (string): chunks/2.2.c684797999dda47217cc.js.LICENSE 1`] = `
 "/***/
 
-/***/
-
 /*! Legal Comment */
 
 /** @license Copyright 2112 Moon. **/
-
-/***/
 "
 `;
 
@@ -86,437 +82,75 @@ exports[`when applied with \`extractComments\` option matches snapshot for a \`a
 
 // webpackBootstrap
 
-/******/
-
 // install a JSONP callback for chunk loading
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // The module cache
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // object to store loaded and loading chunks
-
-/******/
 
 // undefined = chunk not loaded, null = chunk preloaded/prefetched
 
-/******/
-
 // Promise = chunk loading, 0 = chunk loaded
-
-/******/
-
-/******/
-
-/******/
 
 // The require function
 
-/******/
-
-/******/
-
-/******/
-
 // Check if module is in cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // Create a new module (and put it into the cache)
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Execute the module function
-
-/******/
-
-/******/
-
-/******/
 
 // Return the exports of the module
 
-/******/
-
-/******/
-
-/******/
-
 // Flag the module as loaded
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // This file contains only the entry chunk.
 
-/******/
-
 // The chunk loading function for additional chunks
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // JSONP chunk loading for javascript
 
-/******/
-
-/******/
-
-/******/
-
 // 0 means \\"already installed\\".
-
-/******/
-
-/******/
 
 // a Promise means \\"currently loading\\".
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // setup Promise in chunk cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // start chunk loading
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // script path function
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // avoid mem leaks in IE.
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // expose the modules object (__webpack_modules__)
-
-/******/
-
-/******/
-
-/******/
 
 // expose the module cache
 
-/******/
-
-/******/
-
-/******/
-
 // define getter function for harmony exports
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // define __esModule on exports
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // create a fake namespace object
-
-/******/
 
 // mode & 1: value is a module id, require it
 
-/******/
-
 // mode & 2: merge all properties of value into the ns
-
-/******/
 
 // mode & 4: return value when already ns object
 
-/******/
-
 // mode & 8|1: behave like require
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // getDefaultExport function for compatibility with non-harmony modules
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Object.prototype.hasOwnProperty.call
-
-/******/
-
-/******/
-
-/******/
 
 // __webpack_public_path__
 
-/******/
-
-/******/
-
-/******/
-
 // on error function for async loading
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // Load entry module and return exports
 
-/******/
-
-/******/
-
 /************************************************************************/
-
-/******/
 
 /* 0 */
 
@@ -549,8 +183,6 @@ exports[`when applied with \`extractComments\` option matches snapshot for a \`a
 /*
 * Foo
 */
-
-/******/
 "
 `;
 
@@ -564,217 +196,49 @@ exports[`when applied with \`extractComments\` option matches snapshot for a \`a
 
 // webpackBootstrap
 
-/******/
-
 // The module cache
-
-/******/
-
-/******/
-
-/******/
 
 // The require function
 
-/******/
-
-/******/
-
-/******/
-
 // Check if module is in cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // Create a new module (and put it into the cache)
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Execute the module function
-
-/******/
-
-/******/
-
-/******/
 
 // Return the exports of the module
 
-/******/
-
-/******/
-
-/******/
-
 // Flag the module as loaded
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // expose the modules object (__webpack_modules__)
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Load entry module and return exports
-
-/******/
-
-/******/
-
-/******/
 
 // expose the module cache
 
-/******/
-
-/******/
-
-/******/
-
 // define getter function for harmony exports
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // define __esModule on exports
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // create a fake namespace object
-
-/******/
 
 // mode & 1: value is a module id, require it
 
-/******/
-
 // mode & 2: merge all properties of value into the ns
-
-/******/
 
 // mode & 4: return value when already ns object
 
-/******/
-
 // mode & 8|1: behave like require
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // getDefaultExport function for compatibility with non-harmony modules
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Object.prototype.hasOwnProperty.call
-
-/******/
-
-/******/
-
-/******/
 
 // __webpack_public_path__
 
-/******/
-
-/******/
-
 /************************************************************************/
 
-/******/
-
 /* 0 */
-
-/* 1 */
-
-/***/
 
 /* 1 */
 
@@ -784,10 +248,6 @@ exports[`when applied with \`extractComments\` option matches snapshot for a \`a
  * Information.
  * @license MIT
  */
-
-/***/
-
-/******/
 "
 `;
 
@@ -838,13 +298,9 @@ exports[`when applied with \`extractComments\` option matches snapshot for a \`f
 exports[`when applied with \`extractComments\` option matches snapshot for a \`function value: chunks/2.2.c684797999dda47217cc.js.LICENSE 1`] = `
 "/***/
 
-/***/
-
 /*! Legal Comment */
 
 /** @license Copyright 2112 Moon. **/
-
-/***/
 "
 `;
 
@@ -860,437 +316,75 @@ exports[`when applied with \`extractComments\` option matches snapshot for a \`f
 
 // webpackBootstrap
 
-/******/
-
 // install a JSONP callback for chunk loading
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // The module cache
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // object to store loaded and loading chunks
-
-/******/
 
 // undefined = chunk not loaded, null = chunk preloaded/prefetched
 
-/******/
-
 // Promise = chunk loading, 0 = chunk loaded
-
-/******/
-
-/******/
-
-/******/
 
 // The require function
 
-/******/
-
-/******/
-
-/******/
-
 // Check if module is in cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // Create a new module (and put it into the cache)
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Execute the module function
-
-/******/
-
-/******/
-
-/******/
 
 // Return the exports of the module
 
-/******/
-
-/******/
-
-/******/
-
 // Flag the module as loaded
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // This file contains only the entry chunk.
 
-/******/
-
 // The chunk loading function for additional chunks
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // JSONP chunk loading for javascript
 
-/******/
-
-/******/
-
-/******/
-
 // 0 means \\"already installed\\".
-
-/******/
-
-/******/
 
 // a Promise means \\"currently loading\\".
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // setup Promise in chunk cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // start chunk loading
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // script path function
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // avoid mem leaks in IE.
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // expose the modules object (__webpack_modules__)
-
-/******/
-
-/******/
-
-/******/
 
 // expose the module cache
 
-/******/
-
-/******/
-
-/******/
-
 // define getter function for harmony exports
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // define __esModule on exports
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // create a fake namespace object
-
-/******/
 
 // mode & 1: value is a module id, require it
 
-/******/
-
 // mode & 2: merge all properties of value into the ns
-
-/******/
 
 // mode & 4: return value when already ns object
 
-/******/
-
 // mode & 8|1: behave like require
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // getDefaultExport function for compatibility with non-harmony modules
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Object.prototype.hasOwnProperty.call
-
-/******/
-
-/******/
-
-/******/
 
 // __webpack_public_path__
 
-/******/
-
-/******/
-
-/******/
-
 // on error function for async loading
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // Load entry module and return exports
 
-/******/
-
-/******/
-
 /************************************************************************/
-
-/******/
 
 /* 0 */
 
@@ -1323,8 +417,6 @@ exports[`when applied with \`extractComments\` option matches snapshot for a \`f
 /*
 * Foo
 */
-
-/******/
 "
 `;
 
@@ -1338,217 +430,49 @@ exports[`when applied with \`extractComments\` option matches snapshot for a \`f
 
 // webpackBootstrap
 
-/******/
-
 // The module cache
-
-/******/
-
-/******/
-
-/******/
 
 // The require function
 
-/******/
-
-/******/
-
-/******/
-
 // Check if module is in cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // Create a new module (and put it into the cache)
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Execute the module function
-
-/******/
-
-/******/
-
-/******/
 
 // Return the exports of the module
 
-/******/
-
-/******/
-
-/******/
-
 // Flag the module as loaded
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // expose the modules object (__webpack_modules__)
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Load entry module and return exports
-
-/******/
-
-/******/
-
-/******/
 
 // expose the module cache
 
-/******/
-
-/******/
-
-/******/
-
 // define getter function for harmony exports
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // define __esModule on exports
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // create a fake namespace object
-
-/******/
 
 // mode & 1: value is a module id, require it
 
-/******/
-
 // mode & 2: merge all properties of value into the ns
-
-/******/
 
 // mode & 4: return value when already ns object
 
-/******/
-
 // mode & 8|1: behave like require
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // getDefaultExport function for compatibility with non-harmony modules
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Object.prototype.hasOwnProperty.call
-
-/******/
-
-/******/
-
-/******/
 
 // __webpack_public_path__
 
-/******/
-
-/******/
-
 /************************************************************************/
 
-/******/
-
 /* 0 */
-
-/* 1 */
-
-/***/
 
 /* 1 */
 
@@ -1558,10 +482,6 @@ exports[`when applied with \`extractComments\` option matches snapshot for a \`f
  * Information.
  * @license MIT
  */
-
-/***/
-
-/******/
 "
 `;
 
@@ -1750,437 +670,75 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 
 // webpackBootstrap
 
-/******/
-
 // install a JSONP callback for chunk loading
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // The module cache
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // object to store loaded and loading chunks
-
-/******/
 
 // undefined = chunk not loaded, null = chunk preloaded/prefetched
 
-/******/
-
 // Promise = chunk loading, 0 = chunk loaded
-
-/******/
-
-/******/
-
-/******/
 
 // The require function
 
-/******/
-
-/******/
-
-/******/
-
 // Check if module is in cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // Create a new module (and put it into the cache)
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Execute the module function
-
-/******/
-
-/******/
-
-/******/
 
 // Return the exports of the module
 
-/******/
-
-/******/
-
-/******/
-
 // Flag the module as loaded
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // This file contains only the entry chunk.
 
-/******/
-
 // The chunk loading function for additional chunks
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // JSONP chunk loading for javascript
 
-/******/
-
-/******/
-
-/******/
-
 // 0 means \\"already installed\\".
-
-/******/
-
-/******/
 
 // a Promise means \\"currently loading\\".
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // setup Promise in chunk cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // start chunk loading
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // script path function
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // avoid mem leaks in IE.
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // expose the modules object (__webpack_modules__)
-
-/******/
-
-/******/
-
-/******/
 
 // expose the module cache
 
-/******/
-
-/******/
-
-/******/
-
 // define getter function for harmony exports
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // define __esModule on exports
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // create a fake namespace object
-
-/******/
 
 // mode & 1: value is a module id, require it
 
-/******/
-
 // mode & 2: merge all properties of value into the ns
-
-/******/
 
 // mode & 4: return value when already ns object
 
-/******/
-
 // mode & 8|1: behave like require
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // getDefaultExport function for compatibility with non-harmony modules
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Object.prototype.hasOwnProperty.call
-
-/******/
-
-/******/
-
-/******/
 
 // __webpack_public_path__
 
-/******/
-
-/******/
-
-/******/
-
 // on error function for async loading
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // Load entry module and return exports
 
-/******/
-
-/******/
-
 /************************************************************************/
-
-/******/
 
 /* 0 */
 
@@ -2214,246 +772,14 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 * Foo
 */
 
-/******/
-
-/******/
-
-// webpackBootstrap
-
-/******/
-
-// The module cache
-
-/******/
-
-/******/
-
-/******/
-
-// The require function
-
-/******/
-
-/******/
-
-/******/
-
-// Check if module is in cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-// Create a new module (and put it into the cache)
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-// Execute the module function
-
-/******/
-
-/******/
-
-/******/
-
-// Return the exports of the module
-
-/******/
-
-/******/
-
-/******/
-
-// Flag the module as loaded
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-// expose the modules object (__webpack_modules__)
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-// Load entry module and return exports
-
-/******/
-
-/******/
-
-/******/
-
-// expose the module cache
-
-/******/
-
-/******/
-
-/******/
-
-// define getter function for harmony exports
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-// define __esModule on exports
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-// create a fake namespace object
-
-/******/
-
-// mode & 1: value is a module id, require it
-
-/******/
-
-// mode & 2: merge all properties of value into the ns
-
-/******/
-
-// mode & 4: return value when already ns object
-
-/******/
-
-// mode & 8|1: behave like require
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-// getDefaultExport function for compatibility with non-harmony modules
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-// Object.prototype.hasOwnProperty.call
-
-/******/
-
-/******/
-
-/******/
-
-// __webpack_public_path__
-
-/******/
-
-/******/
-
-/************************************************************************/
-
-/******/
-
-/* 0 */
-
 /* 1 */
-
-/***/
-
-/* 1 */
-
-/***/
 
 /**
  * Information.
  * @license MIT
  */
 
-/***/
-
-/******/
-
-/***/
-
-/***/
-
-/*! Legal Comment */
-
 /** @license Copyright 2112 Moon. **/
-
-/***/
 "
 `;
 
@@ -2477,13 +803,9 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 exports[`when applied with \`extractComments\` option matches snapshot for a object value (extracts comments to multiple files): chunks/2.2.c684797999dda47217cc.license.js 1`] = `
 "/***/
 
-/***/
-
 /*! Legal Comment */
 
 /** @license Copyright 2112 Moon. **/
-
-/***/
 "
 `;
 
@@ -2499,437 +821,75 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 
 // webpackBootstrap
 
-/******/
-
 // install a JSONP callback for chunk loading
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // The module cache
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // object to store loaded and loading chunks
-
-/******/
 
 // undefined = chunk not loaded, null = chunk preloaded/prefetched
 
-/******/
-
 // Promise = chunk loading, 0 = chunk loaded
-
-/******/
-
-/******/
-
-/******/
 
 // The require function
 
-/******/
-
-/******/
-
-/******/
-
 // Check if module is in cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // Create a new module (and put it into the cache)
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Execute the module function
-
-/******/
-
-/******/
-
-/******/
 
 // Return the exports of the module
 
-/******/
-
-/******/
-
-/******/
-
 // Flag the module as loaded
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // This file contains only the entry chunk.
 
-/******/
-
 // The chunk loading function for additional chunks
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // JSONP chunk loading for javascript
 
-/******/
-
-/******/
-
-/******/
-
 // 0 means \\"already installed\\".
-
-/******/
-
-/******/
 
 // a Promise means \\"currently loading\\".
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // setup Promise in chunk cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // start chunk loading
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // script path function
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // avoid mem leaks in IE.
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // expose the modules object (__webpack_modules__)
-
-/******/
-
-/******/
-
-/******/
 
 // expose the module cache
 
-/******/
-
-/******/
-
-/******/
-
 // define getter function for harmony exports
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // define __esModule on exports
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // create a fake namespace object
-
-/******/
 
 // mode & 1: value is a module id, require it
 
-/******/
-
 // mode & 2: merge all properties of value into the ns
-
-/******/
 
 // mode & 4: return value when already ns object
 
-/******/
-
 // mode & 8|1: behave like require
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // getDefaultExport function for compatibility with non-harmony modules
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Object.prototype.hasOwnProperty.call
-
-/******/
-
-/******/
-
-/******/
 
 // __webpack_public_path__
 
-/******/
-
-/******/
-
-/******/
-
 // on error function for async loading
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // Load entry module and return exports
 
-/******/
-
-/******/
-
 /************************************************************************/
-
-/******/
 
 /* 0 */
 
@@ -2962,8 +922,6 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 /*
 * Foo
 */
-
-/******/
 "
 `;
 
@@ -2977,217 +935,49 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 
 // webpackBootstrap
 
-/******/
-
 // The module cache
-
-/******/
-
-/******/
-
-/******/
 
 // The require function
 
-/******/
-
-/******/
-
-/******/
-
 // Check if module is in cache
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // Create a new module (and put it into the cache)
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Execute the module function
-
-/******/
-
-/******/
-
-/******/
 
 // Return the exports of the module
 
-/******/
-
-/******/
-
-/******/
-
 // Flag the module as loaded
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // expose the modules object (__webpack_modules__)
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Load entry module and return exports
-
-/******/
-
-/******/
-
-/******/
 
 // expose the module cache
 
-/******/
-
-/******/
-
-/******/
-
 // define getter function for harmony exports
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // define __esModule on exports
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // create a fake namespace object
-
-/******/
 
 // mode & 1: value is a module id, require it
 
-/******/
-
 // mode & 2: merge all properties of value into the ns
-
-/******/
 
 // mode & 4: return value when already ns object
 
-/******/
-
 // mode & 8|1: behave like require
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
 
 // getDefaultExport function for compatibility with non-harmony modules
 
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
-/******/
-
 // Object.prototype.hasOwnProperty.call
-
-/******/
-
-/******/
-
-/******/
 
 // __webpack_public_path__
 
-/******/
-
-/******/
-
 /************************************************************************/
 
-/******/
-
 /* 0 */
-
-/* 1 */
-
-/***/
 
 /* 1 */
 
@@ -3197,10 +987,6 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
  * Information.
  * @license MIT
  */
-
-/***/
-
-/******/
 "
 `;
 


### PR DESCRIPTION
Before appending a comment to a file, make sure the same comment is not already extracted to this file. Previously comments with the same content may be extracted multiple  times to the same file.
Update tests snapshots to reflect this behaviour.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I noticed an [issue](https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/294) in uglifyjs-webpack-plugin, where people requested de-duplication of comments extracted to files. This issue has been closed there because of uglify-es limitations. And since recent version of uglifyjs-webpack-plugin switched from uglify-es to uglify-js, which doesn't support ES6 and I switched from uglifyjs-webpack-plugin to this plugin, I went ahead and implemented de-duplication here :)

### Additional Info

After I implemented the de-duplication, snapshot tests started to fail because snapshots contained a lot of duplicate comments. I updated the snapshots to reflect the change.
