### PR TITLE
feat: option to remove unused cache entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ new TerserPlugin({
 })
 ```
 
+### `compactCache`
+
+Type: `Boolean`
+Default: `false`
+
+When set to `true` removes unused cache entries after each run
+
 ### `parallel`
 
 Type: `Boolean|Number`

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ class TerserPlugin {
       sourceMap = false,
       cache = false,
       cacheKeys = (defaultCacheKeys) => defaultCacheKeys,
+      compactCache = false,
       parallel = false,
       include,
       exclude,
@@ -40,6 +41,7 @@ class TerserPlugin {
       sourceMap,
       cache,
       cacheKeys,
+      compactCache,
       parallel,
       include,
       exclude,
@@ -159,6 +161,7 @@ class TerserPlugin {
     const optimizeFn = (compilation, chunks, callback) => {
       const taskRunner = new TaskRunner({
         cache: this.options.cache,
+        compactCache: this.options.compactCache,
         parallel: this.options.parallel,
       });
 

--- a/src/options.json
+++ b/src/options.json
@@ -77,6 +77,9 @@
     "cacheKeys": {
       "instanceof": "Function"
     },
+    "compactCache": {
+      "type": "boolean"
+    },
     "parallel": {
       "anyOf": [
         {

--- a/test/__snapshots__/cache-option.test.js.snap
+++ b/test/__snapshots__/cache-option.test.js.snap
@@ -116,6 +116,56 @@ exports[`when applied with \`cache\` option matches snapshot for \`true\` value 
 
 exports[`when applied with \`cache\` option matches snapshot for \`true\` value and \`cacheKey\` is custom \`function\`: warnings 2`] = `Array []`;
 
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: errors 1`] = `Array []`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: errors 2`] = `Array []`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: four.ebf50ad84d65226bae69.js 1`] = `"!function(e){var t={};function n(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,n),o.l=!0,o.exports}n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var o in e)n.d(r,o,function(t){return e[t]}.bind(null,o));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,\\"a\\",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p=\\"\\",n(n.s=0)}([function(e,t){e.exports=function(){console.log(7)}}]);"`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: four.ebf50ad84d65226bae69.js 2`] = `
+Array [
+  "four.ebf50ad84d65226bae69.js",
+  "315a383b572bc6e66f67d4d53e36decf",
+]
+`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: one.253593c68c20513789ee.js 1`] = `"!function(e){var t={};function n(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,n),o.l=!0,o.exports}n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var o in e)n.d(r,o,function(t){return e[t]}.bind(null,o));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,\\"a\\",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p=\\"\\",n(n.s=0)}([function(e,t){e.exports=function(){console.log(7)}}]);"`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: one.205342020e30d49ad6f1.js 1`] = `"!function(e){var t={};function n(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,n),o.l=!0,o.exports}n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var o in e)n.d(r,o,function(t){return e[t]}.bind(null,o));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,\\"a\\",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p=\\"\\",n(n.s=0)}([function(e,t){e.exports=function(){console.log(7)}}]);"`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: one.205342020e30d49ad6f1.js 2`] = `
+Array [
+  "one.205342020e30d49ad6f1.js",
+  "315a383b572bc6e66f67d4d53e36decf",
+]
+`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: three.a426ec6da38ad12d3788.js 1`] = `"!function(e){var t={};function n(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,n),o.l=!0,o.exports}n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var o in e)n.d(r,o,function(t){return e[t]}.bind(null,o));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,\\"a\\",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p=\\"\\",n(n.s=0)}([function(e,t){e.exports=function(){console.log(7)}}]);"`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: three.b0a0c7c6dc6636d0ed4f.js 1`] = `"!function(e){var t={};function n(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,n),o.l=!0,o.exports}n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var o in e)n.d(r,o,function(t){return e[t]}.bind(null,o));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,\\"a\\",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p=\\"\\",n(n.s=0)}([function(e,t){e.exports=function(){console.log(7)}}]);"`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: three.b0a0c7c6dc6636d0ed4f.js 2`] = `
+Array [
+  "three.b0a0c7c6dc6636d0ed4f.js",
+  "315a383b572bc6e66f67d4d53e36decf",
+]
+`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: two.7b40de895ec7733c74a4.js 1`] = `"!function(e){var t={};function n(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,n),o.l=!0,o.exports}n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var o in e)n.d(r,o,function(t){return e[t]}.bind(null,o));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,\\"a\\",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p=\\"\\",n(n.s=0)}([function(e,t){e.exports=function(){console.log(7)}}]);"`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: two.7b40de895ec7733c74a4.js 2`] = `
+Array [
+  "two.7b40de895ec7733c74a4.js",
+  "315a383b572bc6e66f67d4d53e36decf",
+]
+`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: two.1611752867c57e8a4bfe.js 1`] = `"!function(e){var t={};function n(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,n),o.l=!0,o.exports}n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var o in e)n.d(r,o,function(t){return e[t]}.bind(null,o));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,\\"a\\",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p=\\"\\",n(n.s=0)}([function(e,t){e.exports=function(){console.log(7)}}]);"`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: warnings 1`] = `Array []`;
+
+exports[`when applied with \`cache\` option matches snapshot for \`true\` value with compactCache set to \`true: warnings 2`] = `Array []`;
+
 exports[`when applied with \`cache\` option matches snapshot for \`true\` value: errors 1`] = `Array []`;
 
 exports[`when applied with \`cache\` option matches snapshot for \`true\` value: errors 2`] = `Array []`;


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
I'm using terser caches to speed up CI builds. But it turned out that unlike say hard-source plugin terser plugin does not cleanup old obsolete caches. This leads to cache size snowballing and build performance degradation

So I've introduced a new option `compactCache` which is set to `false` by default. When enabled it will remove all cache entries that were not a part of the current build.
That way only one set of caches is retained. This means that if you change your code back and forth you'll get cache misses but since terser is mostly used in production builds only that should not be an issue - reverts to exact same old code are rare
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
Nope
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
