### PR TITLE
Disable function inlining by default

### DIFF
--- a/src/minify.js
+++ b/src/minify.js
@@ -7,7 +7,7 @@ const buildTerserOptions = ({
   ecma,
   warnings,
   parse = {},
-  compress = {},
+  compress = { inlining: false },
   mangle,
   module,
   output,


### PR DESCRIPTION
This PR contains a:

- [x] new **feature**

### Motivation / Use-Case

After dealing with evil bugs like [this one](https://github.com/terser-js/terser/issues/244), it seems obvious to me that function inlining behavior in tools like UglifyJS/Terser is silly. Here's another [well-documented bug](https://github.com/mishoo/UglifyJS2/issues/2842) in UglifyJS2.

It's too aggressive, not well-documented, and pointless since engines like V8 will inline function calls anyway. Not to mention that these libaries (Uglify, Terser) are hardly maintained and the entire community still uses them. V8 has built detailed abstractions to handle function inlining in a predictable way; the approach in Terser is more reminiscent of the tales I have heard of the morass of OracleDB.

### Breaking Changes

The behavior isn't documented anyway, so this is hardly breaking.

### Additional Info

Bugs that disappear when you add logging are soul-destroying monsters that no engineer should ever have to deal with. Please disable this behavior by default.
