### PR TITLE
fix: use named imports for terser.minify

### DIFF
--- a/src/minify.js
+++ b/src/minify.js
@@ -1,7 +1,7 @@
 /* eslint-disable
   arrow-body-style
 */
-import terser from 'terser';
+import { minify as terserMinify } from 'terser';
 
 const buildTerserOptions = ({
   ecma,
@@ -175,7 +175,7 @@ const minify = (options) => {
     );
   }
 
-  const { error, map, code, warnings } = terser.minify(
+  const { error, map, code, warnings } = terserMinify(
     { [file]: input },
     terserOptions
   );


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #66, #67 

Named imports have better interoperability than default imports and it is applicable to all versions of terser.