### PR TITLE
Set SourceMap Value based on Webpack Config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { SourceMapConsumer } from 'source-map';
 import { SourceMapSource, RawSource, ConcatSource } from 'webpack-sources';
 import RequestShortener from 'webpack/lib/RequestShortener';
 import ModuleFilenameHelpers from 'webpack/lib/ModuleFilenameHelpers';
+import SourceMapDevToolPlugin from 'webpack/lib/SourceMapDevToolPlugin';
 import validateOptions from 'schema-utils';
 import serialize from 'serialize-javascript';
 import terserPackageJson from 'terser/package.json';
@@ -155,6 +156,15 @@ class TerserPlugin {
   }
 
   apply(compiler) {
+    this.options.sourceMap =
+      this.options.sourceMap ||
+      (compiler.options.devtool &&
+        /source-?map/.test(compiler.options.devtool)) ||
+      (compiler.options.plugins &&
+        compiler.options.plugins.some(
+          (p) => p instanceof SourceMapDevToolPlugin
+        ));
+
     const buildModuleFn = (moduleArg) => {
       // to get detailed location info about errors
       moduleArg.useSourceMap = true;
@@ -187,7 +197,6 @@ class TerserPlugin {
 
           try {
             let input;
-
             if (this.options.sourceMap && asset.sourceAndMap) {
               const { source, map } = asset.sourceAndMap();
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ class TerserPlugin {
       chunkFilter = () => true,
       warningsFilter = () => true,
       extractComments = false,
-      sourceMap = false,
+      sourceMap,
       cache = false,
       cacheKeys = (defaultCacheKeys) => defaultCacheKeys,
       parallel = false,
@@ -156,12 +156,10 @@ class TerserPlugin {
   }
 
   apply(compiler) {
-    this.options.sourceMap = (compiler.options.devtool &&
-        /source-?map/.test(compiler.options.devtool)) ||
-      (compiler.options.plugins &&
-        compiler.options.plugins.some(
-          (p) => p instanceof SourceMapDevToolPlugin
-        ));
+    this.options.sourceMap = this.options.sourceMap === undefined ? 
+      (compiler.options.devtool && /source-?map/.test(compiler.options.devtool)) || 
+      (compiler.options.plugins && compiler.options.plugins.some((p) => p instanceof SourceMapDevToolPlugin))
+        : this.options.sourceMap;
 
     const buildModuleFn = (moduleArg) => {
       // to get detailed location info about errors

--- a/src/index.js
+++ b/src/index.js
@@ -156,9 +156,7 @@ class TerserPlugin {
   }
 
   apply(compiler) {
-    this.options.sourceMap =
-      this.options.sourceMap ||
-      (compiler.options.devtool &&
+    this.options.sourceMap = (compiler.options.devtool &&
         /source-?map/.test(compiler.options.devtool)) ||
       (compiler.options.plugins &&
         compiler.options.plugins.some(

--- a/src/index.js
+++ b/src/index.js
@@ -156,9 +156,14 @@ class TerserPlugin {
   }
 
   apply(compiler) {
-    this.options.sourceMap = this.options.sourceMap === undefined ? 
-      (compiler.options.devtool && /source-?map/.test(compiler.options.devtool)) || 
-      (compiler.options.plugins && compiler.options.plugins.some((p) => p instanceof SourceMapDevToolPlugin))
+    this.options.sourceMap =
+      this.options.sourceMap === undefined
+        ? (compiler.options.devtool &&
+            /source-?map/.test(compiler.options.devtool)) ||
+          (compiler.options.plugins &&
+            compiler.options.plugins.some(
+              (p) => p instanceof SourceMapDevToolPlugin
+            ))
         : this.options.sourceMap;
 
     const buildModuleFn = (moduleArg) => {
@@ -193,6 +198,7 @@ class TerserPlugin {
 
           try {
             let input;
+
             if (this.options.sourceMap && asset.sourceAndMap) {
               const { source, map } = asset.sourceAndMap();
 


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [] **test update** .... working on this
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Basically when switching over to use `terser-webpack-plugin` I wasted some time trying to figure out why sourcemaps weren't working when I had configured it in the plugins for webpack, only to realize I needed to pass `sourceMap: true` to our TerserPlugin. 

I saw that the[ webpack defaults actually already do this](https://github.com/webpack/webpack/blob/6ca9167e9ed0b66e971f9510fe5ea40b364be1b7/lib/WebpackOptionsDefaulter.js#L307), and it seems to make sense to do it here as well and remove the config. 

https://github.com/webpack-contrib/terser-webpack-plugin/issues/71

### Breaking Changes

With this change, the default for `sourceMap` defers to the webpack configuration `devtool` or plugins that use the `SourceMapDevToolPlugin` to define sourcemaps instead of defaulting to `false`. 

### Additional Info
