### PR TITLE
generate higher quality SourceMaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "schema-utils": "^1.0.0",
     "serialize-javascript": "^1.7.0",
     "source-map": "^0.6.1",
-    "terser": "^4.1.2",
+    "terser": "^4.0.0",
     "webpack-sources": "^1.4.0",
     "worker-farm": "^1.7.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -299,7 +299,8 @@ class TerserPlugin {
               file,
               JSON.parse(map),
               input,
-              inputSourceMap
+              inputSourceMap,
+              true
             );
           } else {
             outputSource = new RawSource(code);

--- a/src/minify.js
+++ b/src/minify.js
@@ -158,11 +158,9 @@ const minify = (options) => {
   // Copy terser options
   const terserOptions = buildTerserOptions(options.terserOptions);
 
-  // Add source map data
+  // Let terser generate a SourceMap
   if (inputSourceMap) {
-    terserOptions.sourceMap = {
-      content: inputSourceMap,
-    };
+    terserOptions.sourceMap = true;
   }
 
   const extractedComments = [];

--- a/test/__snapshots__/sourceMap-option.test.js.snap
+++ b/test/__snapshots__/sourceMap-option.test.js.snap
@@ -18,21 +18,73 @@ exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`
 
 exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`false\`): warnings 1`] = `Array []`;
 
-exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`source-map\`) and source map invalid: broken-source-map.js 1`] = `"var test = 1;"`;
+exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`source-map\`) and source map invalid: broken-source-map.js 1`] = `"var test=1;"`;
 
-exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`source-map\`) and source map invalid: errors 1`] = `
-Array [
-  "Error: broken-source-map.js from Terser
-Error: \\"version\\" is a required argument.",
-]
-`;
+exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`source-map\`) and source map invalid: errors 1`] = `Array []`;
 
 exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`source-map\`) and source map invalid: main.570dae94f20910a17e2c.js 1`] = `
 "!function(e){var t={};function n(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,n),o.l=!0,o.exports}n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var o in e)n.d(r,o,function(t){return e[t]}.bind(null,o));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,\\"a\\",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p=\\"\\",n(n.s=0)}([function(e,t){e.exports=function(){console.log(7)}}]);
 //# sourceMappingURL=main.570dae94f20910a17e2c.js.map"
 `;
 
-exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`source-map\`) and source map invalid: main.570dae94f20910a17e2c.js.map 1`] = `"{\\"version\\":3,\\"sources\\":[\\"webpack:///webpack/bootstrap\\",\\"webpack:///./test/fixtures/entry.js\\"],\\"names\\":[\\"installedModules\\",\\"__webpack_require__\\",\\"moduleId\\",\\"exports\\",\\"module\\",\\"i\\",\\"l\\",\\"modules\\",\\"call\\",\\"m\\",\\"c\\",\\"d\\",\\"name\\",\\"getter\\",\\"o\\",\\"Object\\",\\"defineProperty\\",\\"enumerable\\",\\"get\\",\\"r\\",\\"Symbol\\",\\"toStringTag\\",\\"value\\",\\"t\\",\\"mode\\",\\"__esModule\\",\\"ns\\",\\"create\\",\\"key\\",\\"bind\\",\\"n\\",\\"object\\",\\"property\\",\\"prototype\\",\\"hasOwnProperty\\",\\"p\\",\\"s\\",\\"console\\",\\"log\\",\\"b\\"],\\"mappings\\":\\"aACA,IAAAA,EAAA,GAGA,SAAAC,EAAAC,GAGA,GAAAF,EAAAE,GACA,OAAAF,EAAAE,GAAAC,QAGA,IAAAC,EAAAJ,EAAAE,GAAA,CACAG,EAAAH,EACAI,GAAA,EACAH,QAAA,IAUA,OANAI,EAAAL,GAAAM,KAAAJ,EAAAD,QAAAC,IAAAD,QAAAF,GAGAG,EAAAE,GAAA,EAGAF,EAAAD,QAKAF,EAAAQ,EAAAF,EAGAN,EAAAS,EAAAV,EAGAC,EAAAU,EAAA,SAAAR,EAAAS,EAAAC,GACAZ,EAAAa,EAAAX,EAAAS,IACAG,OAAAC,eAAAb,EAAAS,EAAA,CAA0CK,YAAA,EAAAC,IAAAL,KAK1CZ,EAAAkB,EAAA,SAAAhB,GACA,oBAAAiB,eAAAC,aACAN,OAAAC,eAAAb,EAAAiB,OAAAC,YAAA,CAAwDC,MAAA,WAExDP,OAAAC,eAAAb,EAAA,cAAiDmB,OAAA,KAQjDrB,EAAAsB,EAAA,SAAAD,EAAAE,GAEA,GADA,EAAAA,IAAAF,EAAArB,EAAAqB,IACA,EAAAE,EAAA,OAAAF,EACA,KAAAE,GAAA,iBAAAF,QAAAG,WAAA,OAAAH,EACA,IAAAI,EAAAX,OAAAY,OAAA,MAGA,GAFA1B,EAAAkB,EAAAO,GACAX,OAAAC,eAAAU,EAAA,WAAyCT,YAAA,EAAAK,UACzC,EAAAE,GAAA,iBAAAF,EAAA,QAAAM,KAAAN,EAAArB,EAAAU,EAAAe,EAAAE,EAAA,SAAAA,GAAgH,OAAAN,EAAAM,IAAqBC,KAAA,KAAAD,IACrI,OAAAF,GAIAzB,EAAA6B,EAAA,SAAA1B,GACA,IAAAS,EAAAT,KAAAqB,WACA,WAA2B,OAAArB,EAAA,SAC3B,WAAiC,OAAAA,GAEjC,OADAH,EAAAU,EAAAE,EAAA,IAAAA,GACAA,GAIAZ,EAAAa,EAAA,SAAAiB,EAAAC,GAAsD,OAAAjB,OAAAkB,UAAAC,eAAA1B,KAAAuB,EAAAC,IAGtD/B,EAAAkC,EAAA,GAIAlC,IAAAmC,EAAA,mBC7EAhC,EAAAD,QAAA,WAEAkC,QAAAC,IAAAC\\",\\"file\\":\\"main.570dae94f20910a17e2c.js\\",\\"sourcesContent\\":[\\" \\\\t// The module cache\\\\n \\\\tvar installedModules = {};\\\\n\\\\n \\\\t// The require function\\\\n \\\\tfunction __webpack_require__(moduleId) {\\\\n\\\\n \\\\t\\\\t// Check if module is in cache\\\\n \\\\t\\\\tif(installedModules[moduleId]) {\\\\n \\\\t\\\\t\\\\treturn installedModules[moduleId].exports;\\\\n \\\\t\\\\t}\\\\n \\\\t\\\\t// Create a new module (and put it into the cache)\\\\n \\\\t\\\\tvar module = installedModules[moduleId] = {\\\\n \\\\t\\\\t\\\\ti: moduleId,\\\\n \\\\t\\\\t\\\\tl: false,\\\\n \\\\t\\\\t\\\\texports: {}\\\\n \\\\t\\\\t};\\\\n\\\\n \\\\t\\\\t// Execute the module function\\\\n \\\\t\\\\tmodules[moduleId].call(module.exports, module, module.exports, __webpack_require__);\\\\n\\\\n \\\\t\\\\t// Flag the module as loaded\\\\n \\\\t\\\\tmodule.l = true;\\\\n\\\\n \\\\t\\\\t// Return the exports of the module\\\\n \\\\t\\\\treturn module.exports;\\\\n \\\\t}\\\\n\\\\n\\\\n \\\\t// expose the modules object (__webpack_modules__)\\\\n \\\\t__webpack_require__.m = modules;\\\\n\\\\n \\\\t// expose the module cache\\\\n \\\\t__webpack_require__.c = installedModules;\\\\n\\\\n \\\\t// define getter function for harmony exports\\\\n \\\\t__webpack_require__.d = function(exports, name, getter) {\\\\n \\\\t\\\\tif(!__webpack_require__.o(exports, name)) {\\\\n \\\\t\\\\t\\\\tObject.defineProperty(exports, name, { enumerable: true, get: getter });\\\\n \\\\t\\\\t}\\\\n \\\\t};\\\\n\\\\n \\\\t// define __esModule on exports\\\\n \\\\t__webpack_require__.r = function(exports) {\\\\n \\\\t\\\\tif(typeof Symbol !== 'undefined' && Symbol.toStringTag) {\\\\n \\\\t\\\\t\\\\tObject.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });\\\\n \\\\t\\\\t}\\\\n \\\\t\\\\tObject.defineProperty(exports, '__esModule', { value: true });\\\\n \\\\t};\\\\n\\\\n \\\\t// create a fake namespace object\\\\n \\\\t// mode & 1: value is a module id, require it\\\\n \\\\t// mode & 2: merge all properties of value into the ns\\\\n \\\\t// mode & 4: return value when already ns object\\\\n \\\\t// mode & 8|1: behave like require\\\\n \\\\t__webpack_require__.t = function(value, mode) {\\\\n \\\\t\\\\tif(mode & 1) value = __webpack_require__(value);\\\\n \\\\t\\\\tif(mode & 8) return value;\\\\n \\\\t\\\\tif((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;\\\\n \\\\t\\\\tvar ns = Object.create(null);\\\\n \\\\t\\\\t__webpack_require__.r(ns);\\\\n \\\\t\\\\tObject.defineProperty(ns, 'default', { enumerable: true, value: value });\\\\n \\\\t\\\\tif(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));\\\\n \\\\t\\\\treturn ns;\\\\n \\\\t};\\\\n\\\\n \\\\t// getDefaultExport function for compatibility with non-harmony modules\\\\n \\\\t__webpack_require__.n = function(module) {\\\\n \\\\t\\\\tvar getter = module && module.__esModule ?\\\\n \\\\t\\\\t\\\\tfunction getDefault() { return module['default']; } :\\\\n \\\\t\\\\t\\\\tfunction getModuleExports() { return module; };\\\\n \\\\t\\\\t__webpack_require__.d(getter, 'a', getter);\\\\n \\\\t\\\\treturn getter;\\\\n \\\\t};\\\\n\\\\n \\\\t// Object.prototype.hasOwnProperty.call\\\\n \\\\t__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };\\\\n\\\\n \\\\t// __webpack_public_path__\\\\n \\\\t__webpack_require__.p = \\\\\\"\\\\\\";\\\\n\\\\n\\\\n \\\\t// Load entry module and return exports\\\\n \\\\treturn __webpack_require__(__webpack_require__.s = 0);\\\\n\\",\\"// foo\\\\n/* @preserve*/\\\\n// bar\\\\nconst a = 2 + 2;\\\\n\\\\nmodule.exports = function Foo() {\\\\n  const b = 2 + 2;\\\\n  console.log(b + 1 + 2);\\\\n};\\\\n\\"],\\"sourceRoot\\":\\"\\"}"`;
+exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`source-map\`) and source map invalid: main.570dae94f20910a17e2c.js.map 1`] = `
+{
+  "version": 3,
+  "sources": [
+    "webpack:///webpack/bootstrap",
+    "webpack:///./test/fixtures/entry.js"
+  ],
+  "names": [
+    "installedModules",
+    "__webpack_require__",
+    "moduleId",
+    "exports",
+    "module",
+    "i",
+    "l",
+    "modules",
+    "call",
+    "m",
+    "c",
+    "d",
+    "name",
+    "getter",
+    "o",
+    "Object",
+    "defineProperty",
+    "enumerable",
+    "get",
+    "r",
+    "Symbol",
+    "toStringTag",
+    "value",
+    "t",
+    "mode",
+    "__esModule",
+    "ns",
+    "create",
+    "key",
+    "bind",
+    "n",
+    "object",
+    "property",
+    "prototype",
+    "hasOwnProperty",
+    "p",
+    "s",
+    "console",
+    "log",
+    "b"
+  ],
+  "mappings": "aACE,IAAIA,EAAmB,GAGvB,SAASC,EAAoBC,GAG5B,GAAGF,EAAiBE,GACnB,OAAOF,EAAiBE,GAAUC,QAGnC,IAAIC,EAASJ,EAAiBE,GAAY,CACzCG,EAAGH,EACHI,GAAG,EACHH,QAAS,IAUV,OANAI,EAAQL,GAAUM,KAAKJ,EAAOD,QAASC,EAAQA,EAAOD,QAASF,GAG/DG,EAAOE,GAAI,EAGJF,EAAOD,QAKfF,EAAoBQ,EAAIF,EAGxBN,EAAoBS,EAAIV,EAGxBC,EAAoBU,EAAI,SAASR,EAASS,EAAMC,GAC3CZ,EAAoBa,EAAEX,EAASS,IAClCG,OAAOC,eAAeb,EAASS,EAAM,CAAEK,YAAY,EAAMC,IAAKL,KAKhEZ,EAAoBkB,EAAI,SAAShB,GACX,oBAAXiB,QAA0BA,OAAOC,aAC1CN,OAAOC,eAAeb,EAASiB,OAAOC,YAAa,CAAEC,MAAO,WAE7DP,OAAOC,eAAeb,EAAS,aAAc,CAAEmB,OAAO,KAQvDrB,EAAoBsB,EAAI,SAASD,EAAOE,GAEvC,GADU,EAAPA,IAAUF,EAAQrB,EAAoBqB,IAC/B,EAAPE,EAAU,OAAOF,EACpB,GAAW,EAAPE,GAA8B,iBAAVF,GAAsBA,GAASA,EAAMG,WAAY,OAAOH,EAChF,IAAII,EAAKX,OAAOY,OAAO,MAGvB,GAFA1B,EAAoBkB,EAAEO,GACtBX,OAAOC,eAAeU,EAAI,UAAW,CAAET,YAAY,EAAMK,MAAOA,IACtD,EAAPE,GAA4B,iBAATF,EAAmB,IAAI,IAAIM,KAAON,EAAOrB,EAAoBU,EAAEe,EAAIE,EAAK,SAASA,GAAO,OAAON,EAAMM,IAAQC,KAAK,KAAMD,IAC9I,OAAOF,GAIRzB,EAAoB6B,EAAI,SAAS1B,GAChC,IAAIS,EAAST,GAAUA,EAAOqB,WAC7B,WAAwB,OAAOrB,EAAgB,SAC/C,WAA8B,OAAOA,GAEtC,OADAH,EAAoBU,EAAEE,EAAQ,IAAKA,GAC5BA,GAIRZ,EAAoBa,EAAI,SAASiB,EAAQC,GAAY,OAAOjB,OAAOkB,UAAUC,eAAe1B,KAAKuB,EAAQC,IAGzG/B,EAAoBkC,EAAI,GAIjBlC,EAAoBA,EAAoBmC,EAAI,G,gBC7ErDhC,EAAOD,QAAU,WAEfkC,QAAQC,IAAIC",
+  "file": "main.570dae94f20910a17e2c.js",
+  "sourcesContent": [
+    " \\t// The module cache\\n \\tvar installedModules = {};\\n\\n \\t// The require function\\n \\tfunction __webpack_require__(moduleId) {\\n\\n \\t\\t// Check if module is in cache\\n \\t\\tif(installedModules[moduleId]) {\\n \\t\\t\\treturn installedModules[moduleId].exports;\\n \\t\\t}\\n \\t\\t// Create a new module (and put it into the cache)\\n \\t\\tvar module = installedModules[moduleId] = {\\n \\t\\t\\ti: moduleId,\\n \\t\\t\\tl: false,\\n \\t\\t\\texports: {}\\n \\t\\t};\\n\\n \\t\\t// Execute the module function\\n \\t\\tmodules[moduleId].call(module.exports, module, module.exports, __webpack_require__);\\n\\n \\t\\t// Flag the module as loaded\\n \\t\\tmodule.l = true;\\n\\n \\t\\t// Return the exports of the module\\n \\t\\treturn module.exports;\\n \\t}\\n\\n\\n \\t// expose the modules object (__webpack_modules__)\\n \\t__webpack_require__.m = modules;\\n\\n \\t// expose the module cache\\n \\t__webpack_require__.c = installedModules;\\n\\n \\t// define getter function for harmony exports\\n \\t__webpack_require__.d = function(exports, name, getter) {\\n \\t\\tif(!__webpack_require__.o(exports, name)) {\\n \\t\\t\\tObject.defineProperty(exports, name, { enumerable: true, get: getter });\\n \\t\\t}\\n \\t};\\n\\n \\t// define __esModule on exports\\n \\t__webpack_require__.r = function(exports) {\\n \\t\\tif(typeof Symbol !== 'undefined' && Symbol.toStringTag) {\\n \\t\\t\\tObject.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });\\n \\t\\t}\\n \\t\\tObject.defineProperty(exports, '__esModule', { value: true });\\n \\t};\\n\\n \\t// create a fake namespace object\\n \\t// mode & 1: value is a module id, require it\\n \\t// mode & 2: merge all properties of value into the ns\\n \\t// mode & 4: return value when already ns object\\n \\t// mode & 8|1: behave like require\\n \\t__webpack_require__.t = function(value, mode) {\\n \\t\\tif(mode & 1) value = __webpack_require__(value);\\n \\t\\tif(mode & 8) return value;\\n \\t\\tif((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;\\n \\t\\tvar ns = Object.create(null);\\n \\t\\t__webpack_require__.r(ns);\\n \\t\\tObject.defineProperty(ns, 'default', { enumerable: true, value: value });\\n \\t\\tif(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));\\n \\t\\treturn ns;\\n \\t};\\n\\n \\t// getDefaultExport function for compatibility with non-harmony modules\\n \\t__webpack_require__.n = function(module) {\\n \\t\\tvar getter = module && module.__esModule ?\\n \\t\\t\\tfunction getDefault() { return module['default']; } :\\n \\t\\t\\tfunction getModuleExports() { return module; };\\n \\t\\t__webpack_require__.d(getter, 'a', getter);\\n \\t\\treturn getter;\\n \\t};\\n\\n \\t// Object.prototype.hasOwnProperty.call\\n \\t__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };\\n\\n \\t// __webpack_public_path__\\n \\t__webpack_require__.p = \\"\\";\\n\\n\\n \\t// Load entry module and return exports\\n \\treturn __webpack_require__(__webpack_require__.s = 0);\\n",
+    "// foo\\n/* @preserve*/\\n// bar\\nconst a = 2 + 2;\\n\\nmodule.exports = function Foo() {\\n  const b = 2 + 2;\\n  console.log(b + 1 + 2);\\n};\\n"
+  ],
+  "sourceRoot": ""
+}
+`;
 
 exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`source-map\`) and source map invalid: warnings 1`] = `
 Array [
@@ -47,6 +99,63 @@ exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`
 //# sourceMappingURL=main.570dae94f20910a17e2c.js.map"
 `;
 
-exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`source-map\`): main.570dae94f20910a17e2c.js.map 1`] = `"{\\"version\\":3,\\"sources\\":[\\"webpack:///webpack/bootstrap\\",\\"webpack:///./test/fixtures/entry.js\\"],\\"names\\":[\\"installedModules\\",\\"__webpack_require__\\",\\"moduleId\\",\\"exports\\",\\"module\\",\\"i\\",\\"l\\",\\"modules\\",\\"call\\",\\"m\\",\\"c\\",\\"d\\",\\"name\\",\\"getter\\",\\"o\\",\\"Object\\",\\"defineProperty\\",\\"enumerable\\",\\"get\\",\\"r\\",\\"Symbol\\",\\"toStringTag\\",\\"value\\",\\"t\\",\\"mode\\",\\"__esModule\\",\\"ns\\",\\"create\\",\\"key\\",\\"bind\\",\\"n\\",\\"object\\",\\"property\\",\\"prototype\\",\\"hasOwnProperty\\",\\"p\\",\\"s\\",\\"console\\",\\"log\\",\\"b\\"],\\"mappings\\":\\"aACA,IAAAA,EAAA,GAGA,SAAAC,EAAAC,GAGA,GAAAF,EAAAE,GACA,OAAAF,EAAAE,GAAAC,QAGA,IAAAC,EAAAJ,EAAAE,GAAA,CACAG,EAAAH,EACAI,GAAA,EACAH,QAAA,IAUA,OANAI,EAAAL,GAAAM,KAAAJ,EAAAD,QAAAC,IAAAD,QAAAF,GAGAG,EAAAE,GAAA,EAGAF,EAAAD,QAKAF,EAAAQ,EAAAF,EAGAN,EAAAS,EAAAV,EAGAC,EAAAU,EAAA,SAAAR,EAAAS,EAAAC,GACAZ,EAAAa,EAAAX,EAAAS,IACAG,OAAAC,eAAAb,EAAAS,EAAA,CAA0CK,YAAA,EAAAC,IAAAL,KAK1CZ,EAAAkB,EAAA,SAAAhB,GACA,oBAAAiB,eAAAC,aACAN,OAAAC,eAAAb,EAAAiB,OAAAC,YAAA,CAAwDC,MAAA,WAExDP,OAAAC,eAAAb,EAAA,cAAiDmB,OAAA,KAQjDrB,EAAAsB,EAAA,SAAAD,EAAAE,GAEA,GADA,EAAAA,IAAAF,EAAArB,EAAAqB,IACA,EAAAE,EAAA,OAAAF,EACA,KAAAE,GAAA,iBAAAF,QAAAG,WAAA,OAAAH,EACA,IAAAI,EAAAX,OAAAY,OAAA,MAGA,GAFA1B,EAAAkB,EAAAO,GACAX,OAAAC,eAAAU,EAAA,WAAyCT,YAAA,EAAAK,UACzC,EAAAE,GAAA,iBAAAF,EAAA,QAAAM,KAAAN,EAAArB,EAAAU,EAAAe,EAAAE,EAAA,SAAAA,GAAgH,OAAAN,EAAAM,IAAqBC,KAAA,KAAAD,IACrI,OAAAF,GAIAzB,EAAA6B,EAAA,SAAA1B,GACA,IAAAS,EAAAT,KAAAqB,WACA,WAA2B,OAAArB,EAAA,SAC3B,WAAiC,OAAAA,GAEjC,OADAH,EAAAU,EAAAE,EAAA,IAAAA,GACAA,GAIAZ,EAAAa,EAAA,SAAAiB,EAAAC,GAAsD,OAAAjB,OAAAkB,UAAAC,eAAA1B,KAAAuB,EAAAC,IAGtD/B,EAAAkC,EAAA,GAIAlC,IAAAmC,EAAA,mBC7EAhC,EAAAD,QAAA,WAEAkC,QAAAC,IAAAC\\",\\"file\\":\\"main.570dae94f20910a17e2c.js\\",\\"sourcesContent\\":[\\" \\\\t// The module cache\\\\n \\\\tvar installedModules = {};\\\\n\\\\n \\\\t// The require function\\\\n \\\\tfunction __webpack_require__(moduleId) {\\\\n\\\\n \\\\t\\\\t// Check if module is in cache\\\\n \\\\t\\\\tif(installedModules[moduleId]) {\\\\n \\\\t\\\\t\\\\treturn installedModules[moduleId].exports;\\\\n \\\\t\\\\t}\\\\n \\\\t\\\\t// Create a new module (and put it into the cache)\\\\n \\\\t\\\\tvar module = installedModules[moduleId] = {\\\\n \\\\t\\\\t\\\\ti: moduleId,\\\\n \\\\t\\\\t\\\\tl: false,\\\\n \\\\t\\\\t\\\\texports: {}\\\\n \\\\t\\\\t};\\\\n\\\\n \\\\t\\\\t// Execute the module function\\\\n \\\\t\\\\tmodules[moduleId].call(module.exports, module, module.exports, __webpack_require__);\\\\n\\\\n \\\\t\\\\t// Flag the module as loaded\\\\n \\\\t\\\\tmodule.l = true;\\\\n\\\\n \\\\t\\\\t// Return the exports of the module\\\\n \\\\t\\\\treturn module.exports;\\\\n \\\\t}\\\\n\\\\n\\\\n \\\\t// expose the modules object (__webpack_modules__)\\\\n \\\\t__webpack_require__.m = modules;\\\\n\\\\n \\\\t// expose the module cache\\\\n \\\\t__webpack_require__.c = installedModules;\\\\n\\\\n \\\\t// define getter function for harmony exports\\\\n \\\\t__webpack_require__.d = function(exports, name, getter) {\\\\n \\\\t\\\\tif(!__webpack_require__.o(exports, name)) {\\\\n \\\\t\\\\t\\\\tObject.defineProperty(exports, name, { enumerable: true, get: getter });\\\\n \\\\t\\\\t}\\\\n \\\\t};\\\\n\\\\n \\\\t// define __esModule on exports\\\\n \\\\t__webpack_require__.r = function(exports) {\\\\n \\\\t\\\\tif(typeof Symbol !== 'undefined' && Symbol.toStringTag) {\\\\n \\\\t\\\\t\\\\tObject.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });\\\\n \\\\t\\\\t}\\\\n \\\\t\\\\tObject.defineProperty(exports, '__esModule', { value: true });\\\\n \\\\t};\\\\n\\\\n \\\\t// create a fake namespace object\\\\n \\\\t// mode & 1: value is a module id, require it\\\\n \\\\t// mode & 2: merge all properties of value into the ns\\\\n \\\\t// mode & 4: return value when already ns object\\\\n \\\\t// mode & 8|1: behave like require\\\\n \\\\t__webpack_require__.t = function(value, mode) {\\\\n \\\\t\\\\tif(mode & 1) value = __webpack_require__(value);\\\\n \\\\t\\\\tif(mode & 8) return value;\\\\n \\\\t\\\\tif((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;\\\\n \\\\t\\\\tvar ns = Object.create(null);\\\\n \\\\t\\\\t__webpack_require__.r(ns);\\\\n \\\\t\\\\tObject.defineProperty(ns, 'default', { enumerable: true, value: value });\\\\n \\\\t\\\\tif(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));\\\\n \\\\t\\\\treturn ns;\\\\n \\\\t};\\\\n\\\\n \\\\t// getDefaultExport function for compatibility with non-harmony modules\\\\n \\\\t__webpack_require__.n = function(module) {\\\\n \\\\t\\\\tvar getter = module && module.__esModule ?\\\\n \\\\t\\\\t\\\\tfunction getDefault() { return module['default']; } :\\\\n \\\\t\\\\t\\\\tfunction getModuleExports() { return module; };\\\\n \\\\t\\\\t__webpack_require__.d(getter, 'a', getter);\\\\n \\\\t\\\\treturn getter;\\\\n \\\\t};\\\\n\\\\n \\\\t// Object.prototype.hasOwnProperty.call\\\\n \\\\t__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };\\\\n\\\\n \\\\t// __webpack_public_path__\\\\n \\\\t__webpack_require__.p = \\\\\\"\\\\\\";\\\\n\\\\n\\\\n \\\\t// Load entry module and return exports\\\\n \\\\treturn __webpack_require__(__webpack_require__.s = 0);\\\\n\\",\\"// foo\\\\n/* @preserve*/\\\\n// bar\\\\nconst a = 2 + 2;\\\\n\\\\nmodule.exports = function Foo() {\\\\n  const b = 2 + 2;\\\\n  console.log(b + 1 + 2);\\\\n};\\\\n\\"],\\"sourceRoot\\":\\"\\"}"`;
+exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`source-map\`): main.570dae94f20910a17e2c.js.map 1`] = `
+{
+  "version": 3,
+  "sources": [
+    "webpack:///webpack/bootstrap",
+    "webpack:///./test/fixtures/entry.js"
+  ],
+  "names": [
+    "installedModules",
+    "__webpack_require__",
+    "moduleId",
+    "exports",
+    "module",
+    "i",
+    "l",
+    "modules",
+    "call",
+    "m",
+    "c",
+    "d",
+    "name",
+    "getter",
+    "o",
+    "Object",
+    "defineProperty",
+    "enumerable",
+    "get",
+    "r",
+    "Symbol",
+    "toStringTag",
+    "value",
+    "t",
+    "mode",
+    "__esModule",
+    "ns",
+    "create",
+    "key",
+    "bind",
+    "n",
+    "object",
+    "property",
+    "prototype",
+    "hasOwnProperty",
+    "p",
+    "s",
+    "console",
+    "log",
+    "b"
+  ],
+  "mappings": "aACE,IAAIA,EAAmB,GAGvB,SAASC,EAAoBC,GAG5B,GAAGF,EAAiBE,GACnB,OAAOF,EAAiBE,GAAUC,QAGnC,IAAIC,EAASJ,EAAiBE,GAAY,CACzCG,EAAGH,EACHI,GAAG,EACHH,QAAS,IAUV,OANAI,EAAQL,GAAUM,KAAKJ,EAAOD,QAASC,EAAQA,EAAOD,QAASF,GAG/DG,EAAOE,GAAI,EAGJF,EAAOD,QAKfF,EAAoBQ,EAAIF,EAGxBN,EAAoBS,EAAIV,EAGxBC,EAAoBU,EAAI,SAASR,EAASS,EAAMC,GAC3CZ,EAAoBa,EAAEX,EAASS,IAClCG,OAAOC,eAAeb,EAASS,EAAM,CAAEK,YAAY,EAAMC,IAAKL,KAKhEZ,EAAoBkB,EAAI,SAAShB,GACX,oBAAXiB,QAA0BA,OAAOC,aAC1CN,OAAOC,eAAeb,EAASiB,OAAOC,YAAa,CAAEC,MAAO,WAE7DP,OAAOC,eAAeb,EAAS,aAAc,CAAEmB,OAAO,KAQvDrB,EAAoBsB,EAAI,SAASD,EAAOE,GAEvC,GADU,EAAPA,IAAUF,EAAQrB,EAAoBqB,IAC/B,EAAPE,EAAU,OAAOF,EACpB,GAAW,EAAPE,GAA8B,iBAAVF,GAAsBA,GAASA,EAAMG,WAAY,OAAOH,EAChF,IAAII,EAAKX,OAAOY,OAAO,MAGvB,GAFA1B,EAAoBkB,EAAEO,GACtBX,OAAOC,eAAeU,EAAI,UAAW,CAAET,YAAY,EAAMK,MAAOA,IACtD,EAAPE,GAA4B,iBAATF,EAAmB,IAAI,IAAIM,KAAON,EAAOrB,EAAoBU,EAAEe,EAAIE,EAAK,SAASA,GAAO,OAAON,EAAMM,IAAQC,KAAK,KAAMD,IAC9I,OAAOF,GAIRzB,EAAoB6B,EAAI,SAAS1B,GAChC,IAAIS,EAAST,GAAUA,EAAOqB,WAC7B,WAAwB,OAAOrB,EAAgB,SAC/C,WAA8B,OAAOA,GAEtC,OADAH,EAAoBU,EAAEE,EAAQ,IAAKA,GAC5BA,GAIRZ,EAAoBa,EAAI,SAASiB,EAAQC,GAAY,OAAOjB,OAAOkB,UAAUC,eAAe1B,KAAKuB,EAAQC,IAGzG/B,EAAoBkC,EAAI,GAIjBlC,EAAoBA,EAAoBmC,EAAI,G,gBC7ErDhC,EAAOD,QAAU,WAEfkC,QAAQC,IAAIC",
+  "file": "main.570dae94f20910a17e2c.js",
+  "sourcesContent": [
+    " \\t// The module cache\\n \\tvar installedModules = {};\\n\\n \\t// The require function\\n \\tfunction __webpack_require__(moduleId) {\\n\\n \\t\\t// Check if module is in cache\\n \\t\\tif(installedModules[moduleId]) {\\n \\t\\t\\treturn installedModules[moduleId].exports;\\n \\t\\t}\\n \\t\\t// Create a new module (and put it into the cache)\\n \\t\\tvar module = installedModules[moduleId] = {\\n \\t\\t\\ti: moduleId,\\n \\t\\t\\tl: false,\\n \\t\\t\\texports: {}\\n \\t\\t};\\n\\n \\t\\t// Execute the module function\\n \\t\\tmodules[moduleId].call(module.exports, module, module.exports, __webpack_require__);\\n\\n \\t\\t// Flag the module as loaded\\n \\t\\tmodule.l = true;\\n\\n \\t\\t// Return the exports of the module\\n \\t\\treturn module.exports;\\n \\t}\\n\\n\\n \\t// expose the modules object (__webpack_modules__)\\n \\t__webpack_require__.m = modules;\\n\\n \\t// expose the module cache\\n \\t__webpack_require__.c = installedModules;\\n\\n \\t// define getter function for harmony exports\\n \\t__webpack_require__.d = function(exports, name, getter) {\\n \\t\\tif(!__webpack_require__.o(exports, name)) {\\n \\t\\t\\tObject.defineProperty(exports, name, { enumerable: true, get: getter });\\n \\t\\t}\\n \\t};\\n\\n \\t// define __esModule on exports\\n \\t__webpack_require__.r = function(exports) {\\n \\t\\tif(typeof Symbol !== 'undefined' && Symbol.toStringTag) {\\n \\t\\t\\tObject.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });\\n \\t\\t}\\n \\t\\tObject.defineProperty(exports, '__esModule', { value: true });\\n \\t};\\n\\n \\t// create a fake namespace object\\n \\t// mode & 1: value is a module id, require it\\n \\t// mode & 2: merge all properties of value into the ns\\n \\t// mode & 4: return value when already ns object\\n \\t// mode & 8|1: behave like require\\n \\t__webpack_require__.t = function(value, mode) {\\n \\t\\tif(mode & 1) value = __webpack_require__(value);\\n \\t\\tif(mode & 8) return value;\\n \\t\\tif((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;\\n \\t\\tvar ns = Object.create(null);\\n \\t\\t__webpack_require__.r(ns);\\n \\t\\tObject.defineProperty(ns, 'default', { enumerable: true, value: value });\\n \\t\\tif(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));\\n \\t\\treturn ns;\\n \\t};\\n\\n \\t// getDefaultExport function for compatibility with non-harmony modules\\n \\t__webpack_require__.n = function(module) {\\n \\t\\tvar getter = module && module.__esModule ?\\n \\t\\t\\tfunction getDefault() { return module['default']; } :\\n \\t\\t\\tfunction getModuleExports() { return module; };\\n \\t\\t__webpack_require__.d(getter, 'a', getter);\\n \\t\\treturn getter;\\n \\t};\\n\\n \\t// Object.prototype.hasOwnProperty.call\\n \\t__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };\\n\\n \\t// __webpack_public_path__\\n \\t__webpack_require__.p = \\"\\";\\n\\n\\n \\t// Load entry module and return exports\\n \\treturn __webpack_require__(__webpack_require__.s = 0);\\n",
+    "// foo\\n/* @preserve*/\\n// bar\\nconst a = 2 + 2;\\n\\nmodule.exports = function Foo() {\\n  const b = 2 + 2;\\n  console.log(b + 1 + 2);\\n};\\n"
+  ],
+  "sourceRoot": ""
+}
+`;
 
 exports[`when options.sourceMap matches snapshot for a single \`true\` value (\`devtool\` is \`source-map\`): warnings 1`] = `Array []`;

--- a/test/__snapshots__/worker.test.js.snap
+++ b/test/__snapshots__/worker.test.js.snap
@@ -55,7 +55,7 @@ Object {
   "code": "function foo(f){if(f)return bar()}",
   "error": undefined,
   "extractedComments": Array [],
-  "map": "{\\"version\\":3,\\"sources\\":[\\"test1.js\\"],\\"names\\":[\\"foo\\",\\"x\\",\\"not_called1\\"],\\"mappings\\":\\"AAAA,SAASA,IAAIC,GACT,GACIA,EAAA,OACAC\\"}",
+  "map": "{\\"version\\":3,\\"sources\\":[\\"test6.js\\"],\\"names\\":[\\"foo\\",\\"x\\",\\"bar\\"],\\"mappings\\":\\"AAAA,SAASA,IAAIC,GAAK,GAAIA,EAAK,OAAOC\\"}",
   "warnings": undefined,
 }
 `;

--- a/test/sourceMap-option.test.js
+++ b/test/sourceMap-option.test.js
@@ -2,6 +2,19 @@ import TerserPlugin from '../src/index';
 
 import { createCompiler, compile, cleanErrorStack } from './helpers';
 
+expect.addSnapshotSerializer({
+  test: (value) => {
+    // For string that are valid JSON
+    if (typeof value !== 'string') return false;
+    try {
+      return typeof JSON.parse(value) === 'object';
+    } catch (e) {
+      return false;
+    }
+  },
+  print: (value) => JSON.stringify(JSON.parse(value), null, 2),
+});
+
 describe('when options.sourceMap', () => {
   it('matches snapshot for a single `false` value (`devtool` is `source-map`)', () => {
     const compiler = createCompiler({


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes https://github.com/webpack/webpack/issues/8302

Mappings generated when combining bundle source map with terser source map are not very fine, which leads to validation errors and low quality source maps.

There are many causes:

* webpack generates mappings that map a line to a line
* The SourceMap spec has no idea of: "this is a copied line"

We had a similar problem with webpack replacements (using the `ReplaceSource` from webpack-sources) and a good fix turned out to be:

Assume that mappings, where generates source and original source are identical for a mapping, map source code char by char.

With this assumption mappings don't have to be super exact as long code stays equal. This allows to apply the high quality terser SourceMap to the lower quality webpack SourceMap without loosing quality.

webpack-sources now implements with kind of assumption (I call it "identity" mappings) for `SourceMapSource`. This PR changes terser-webpack-plugin to use it.

Test snapshots are updated with new mappings that include more column information.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

This should have no breaking changes. SourceMaps are very similar, but with additional column information.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

For reviewing see only second commit. First commit changes snapshot format to be easier reviewable.