### PR TITLE
fix: make `extractComments` API more consistent

### DIFF
--- a/src/minify.js
+++ b/src/minify.js
@@ -49,6 +49,8 @@ const buildTerserOptions = ({
   safari10,
 });
 
+const someCommentsRegExp = /^\**!|@preserve|@license|@cc_on/i;
+
 const buildComments = (options, terserOptions, extractedComments) => {
   const condition = {};
   const commentsOpts = terserOptions.output.comments;
@@ -56,7 +58,7 @@ const buildComments = (options, terserOptions, extractedComments) => {
   // Use /^\**!|@preserve|@license|@cc_on/i RegExp
   if (typeof options.extractComments === 'boolean') {
     condition.preserve = commentsOpts;
-    condition.extract = /^\**!|@preserve|@license|@cc_on/i;
+    condition.extract = someCommentsRegExp;
   } else if (
     typeof options.extractComments === 'string' ||
     options.extractComments instanceof RegExp
@@ -72,7 +74,11 @@ const buildComments = (options, terserOptions, extractedComments) => {
   ) {
     // Extract condition is given in extractComments.condition
     condition.preserve = commentsOpts;
-    condition.extract = options.extractComments.condition;
+    condition.extract =
+      typeof options.extractComments.condition === 'boolean' &&
+      options.extractComments.condition
+        ? 'some'
+        : options.extractComments.condition;
   } else {
     // No extract condition is given. Extract comments that match commentsOpts instead of preserving them
     condition.preserve = false;
@@ -102,7 +108,7 @@ const buildComments = (options, terserOptions, extractedComments) => {
           condition[key] = (astNode, comment) => {
             return (
               comment.type === 'comment2' &&
-              /^\**!|@preserve|@license|@cc_on/i.test(comment.value)
+              someCommentsRegExp.test(comment.value)
             );
           };
 

--- a/test/__snapshots__/extractComments-option.test.js.snap
+++ b/test/__snapshots__/extractComments-option.test.js.snap
@@ -1153,92 +1153,10 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 exports[`when applied with \`extractComments\` option matches snapshot for a object value (extracts comments to a single file) and dedupe duplicate comments: errors 1`] = `Array []`;
 
 exports[`when applied with \`extractComments\` option matches snapshot for a object value (extracts comments to a single file) and dedupe duplicate comments: extracted-comments.js 1`] = `
-"/******/
-
-// webpackBootstrap
-
-// The module cache
-
-// The require function
-
-// Check if module is in cache
-
-// Create a new module (and put it into the cache)
-
-// Execute the module function
-
-// Return the exports of the module
-
-// Flag the module as loaded
-
-// expose the modules object (__webpack_modules__)
-
-// Load entry module and return exports
-
-// expose the module cache
-
-// define getter function for harmony exports
-
-// define __esModule on exports
-
-// create a fake namespace object
-
-// mode & 1: value is a module id, require it
-
-// mode & 2: merge all properties of value into the ns
-
-// mode & 4: return value when already ns object
-
-// mode & 8|1: behave like require
-
-// getDefaultExport function for compatibility with non-harmony modules
-
-// Object.prototype.hasOwnProperty.call
-
-// __webpack_public_path__
-
-/************************************************************************/
-
-/***/
-
-/**
+"/**
  * Duplicate comment in difference files.
  * @license MIT
  */
-
-// install a JSONP callback for chunk loading
-
-// object to store loaded and loading chunks
-
-// undefined = chunk not loaded, null = chunk preloaded/prefetched
-
-// Promise = chunk loading, 0 = chunk loaded
-
-// This file contains only the entry chunk.
-
-// The chunk loading function for additional chunks
-
-// JSONP chunk loading for javascript
-
-// 0 means \\"already installed\\".
-
-// a Promise means \\"currently loading\\".
-
-// setup Promise in chunk cache
-
-// start chunk loading
-
-// script path function
-
-// create error before stack unwound to get useful stacktrace later
-
-// avoid mem leaks in IE.
-
-// on error function for async loading
-
-/* 0 */
-
-/* import() */
 
 /*! Legal Comment */
 
@@ -1256,22 +1174,10 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 
 /*! Legal Foo */
 
-// Foo
-
-/*
- Foo Bar
- */
-
-/*
-* Foo
-*/
-
 /**
  * Duplicate comment in same file.
  * @license MIT
  */
-
-/* 1 */
 
 /**
  * Information.
@@ -1312,92 +1218,10 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 exports[`when applied with \`extractComments\` option matches snapshot for a object value (extracts comments to a single file): errors 1`] = `Array []`;
 
 exports[`when applied with \`extractComments\` option matches snapshot for a object value (extracts comments to a single file): extracted-comments.js 1`] = `
-"/******/
-
-// webpackBootstrap
-
-// The module cache
-
-// The require function
-
-// Check if module is in cache
-
-// Create a new module (and put it into the cache)
-
-// Execute the module function
-
-// Return the exports of the module
-
-// Flag the module as loaded
-
-// expose the modules object (__webpack_modules__)
-
-// Load entry module and return exports
-
-// expose the module cache
-
-// define getter function for harmony exports
-
-// define __esModule on exports
-
-// create a fake namespace object
-
-// mode & 1: value is a module id, require it
-
-// mode & 2: merge all properties of value into the ns
-
-// mode & 4: return value when already ns object
-
-// mode & 8|1: behave like require
-
-// getDefaultExport function for compatibility with non-harmony modules
-
-// Object.prototype.hasOwnProperty.call
-
-// __webpack_public_path__
-
-/************************************************************************/
-
-/***/
-
-/**
+"/**
  * Duplicate comment in difference files.
  * @license MIT
  */
-
-// install a JSONP callback for chunk loading
-
-// object to store loaded and loading chunks
-
-// undefined = chunk not loaded, null = chunk preloaded/prefetched
-
-// Promise = chunk loading, 0 = chunk loaded
-
-// This file contains only the entry chunk.
-
-// The chunk loading function for additional chunks
-
-// JSONP chunk loading for javascript
-
-// 0 means \\"already installed\\".
-
-// a Promise means \\"currently loading\\".
-
-// setup Promise in chunk cache
-
-// start chunk loading
-
-// script path function
-
-// create error before stack unwound to get useful stacktrace later
-
-// avoid mem leaks in IE.
-
-// on error function for async loading
-
-/* 0 */
-
-/* import() */
 
 /*! Legal Comment */
 
@@ -1415,22 +1239,10 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 
 /*! Legal Foo */
 
-// Foo
-
-/*
- Foo Bar
- */
-
-/*
-* Foo
-*/
-
 /**
  * Duplicate comment in same file.
  * @license MIT
  */
-
-/* 1 */
 
 /**
  * Information.
@@ -1469,9 +1281,7 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 `;
 
 exports[`when applied with \`extractComments\` option matches snapshot for a object value (extracts comments to multiple files): chunks/4.4.a768ff21a59584840b5e.license.js 1`] = `
-"/***/
-
-/*! Legal Comment */
+"/*! Legal Comment */
 
 /** @license Copyright 2112 Moon. **/
 "
@@ -1485,55 +1295,7 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 `;
 
 exports[`when applied with \`extractComments\` option matches snapshot for a object value (extracts comments to multiple files): filename/four.a51029ee38b02246ba30.license.js 1`] = `
-"/******/
-
-// webpackBootstrap
-
-// The module cache
-
-// The require function
-
-// Check if module is in cache
-
-// Create a new module (and put it into the cache)
-
-// Execute the module function
-
-// Return the exports of the module
-
-// Flag the module as loaded
-
-// expose the modules object (__webpack_modules__)
-
-// Load entry module and return exports
-
-// expose the module cache
-
-// define getter function for harmony exports
-
-// define __esModule on exports
-
-// create a fake namespace object
-
-// mode & 1: value is a module id, require it
-
-// mode & 2: merge all properties of value into the ns
-
-// mode & 4: return value when already ns object
-
-// mode & 8|1: behave like require
-
-// getDefaultExport function for compatibility with non-harmony modules
-
-// Object.prototype.hasOwnProperty.call
-
-// __webpack_public_path__
-
-/************************************************************************/
-
-/***/
-
-/**
+"/**
  * Duplicate comment in difference files.
  * @license MIT
  */
@@ -1546,89 +1308,7 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 `;
 
 exports[`when applied with \`extractComments\` option matches snapshot for a object value (extracts comments to multiple files): filename/one.e5466f67949ca359f275.license.js 1`] = `
-"/******/
-
-// webpackBootstrap
-
-// install a JSONP callback for chunk loading
-
-// The module cache
-
-// object to store loaded and loading chunks
-
-// undefined = chunk not loaded, null = chunk preloaded/prefetched
-
-// Promise = chunk loading, 0 = chunk loaded
-
-// The require function
-
-// Check if module is in cache
-
-// Create a new module (and put it into the cache)
-
-// Execute the module function
-
-// Return the exports of the module
-
-// Flag the module as loaded
-
-// This file contains only the entry chunk.
-
-// The chunk loading function for additional chunks
-
-// JSONP chunk loading for javascript
-
-// 0 means \\"already installed\\".
-
-// a Promise means \\"currently loading\\".
-
-// setup Promise in chunk cache
-
-// start chunk loading
-
-// script path function
-
-// create error before stack unwound to get useful stacktrace later
-
-// avoid mem leaks in IE.
-
-// expose the modules object (__webpack_modules__)
-
-// expose the module cache
-
-// define getter function for harmony exports
-
-// define __esModule on exports
-
-// create a fake namespace object
-
-// mode & 1: value is a module id, require it
-
-// mode & 2: merge all properties of value into the ns
-
-// mode & 4: return value when already ns object
-
-// mode & 8|1: behave like require
-
-// getDefaultExport function for compatibility with non-harmony modules
-
-// Object.prototype.hasOwnProperty.call
-
-// __webpack_public_path__
-
-// on error function for async loading
-
-// Load entry module and return exports
-
-/************************************************************************/
-
-/* 0 */
-
-/***/
-
-/* import() */
-
-/*! Legal Comment */
+"/*! Legal Comment */
 
 /**
  * @preserve Copyright 2009 SomeThirdParty.
@@ -1643,16 +1323,6 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
  */
 
 /*! Legal Foo */
-
-// Foo
-
-/*
- Foo Bar
- */
-
-/*
-* Foo
-*/
 "
 `;
 
@@ -1662,55 +1332,7 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 `;
 
 exports[`when applied with \`extractComments\` option matches snapshot for a object value (extracts comments to multiple files): filename/three.97df6fa9df169616d269.license.js 1`] = `
-"/******/
-
-// webpackBootstrap
-
-// The module cache
-
-// The require function
-
-// Check if module is in cache
-
-// Create a new module (and put it into the cache)
-
-// Execute the module function
-
-// Return the exports of the module
-
-// Flag the module as loaded
-
-// expose the modules object (__webpack_modules__)
-
-// Load entry module and return exports
-
-// expose the module cache
-
-// define getter function for harmony exports
-
-// define __esModule on exports
-
-// create a fake namespace object
-
-// mode & 1: value is a module id, require it
-
-// mode & 2: merge all properties of value into the ns
-
-// mode & 4: return value when already ns object
-
-// mode & 8|1: behave like require
-
-// getDefaultExport function for compatibility with non-harmony modules
-
-// Object.prototype.hasOwnProperty.call
-
-// __webpack_public_path__
-
-/************************************************************************/
-
-/***/
-
-/**
+"/**
  * Duplicate comment in same file.
  * @license MIT
  */
@@ -1728,59 +1350,7 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 `;
 
 exports[`when applied with \`extractComments\` option matches snapshot for a object value (extracts comments to multiple files): filename/two.c8f73e41372935d939d4.license.js 1`] = `
-"/******/
-
-// webpackBootstrap
-
-// The module cache
-
-// The require function
-
-// Check if module is in cache
-
-// Create a new module (and put it into the cache)
-
-// Execute the module function
-
-// Return the exports of the module
-
-// Flag the module as loaded
-
-// expose the modules object (__webpack_modules__)
-
-// Load entry module and return exports
-
-// expose the module cache
-
-// define getter function for harmony exports
-
-// define __esModule on exports
-
-// create a fake namespace object
-
-// mode & 1: value is a module id, require it
-
-// mode & 2: merge all properties of value into the ns
-
-// mode & 4: return value when already ns object
-
-// mode & 8|1: behave like require
-
-// getDefaultExport function for compatibility with non-harmony modules
-
-// Object.prototype.hasOwnProperty.call
-
-// __webpack_public_path__
-
-/************************************************************************/
-
-/* 0 */
-
-/* 1 */
-
-/***/
-
-/**
+"/**
  * Information.
  * @license MIT
  */
@@ -1859,6 +1429,90 @@ exports[`when applied with \`extractComments\` option matches snapshot for a obj
 `;
 
 exports[`when applied with \`extractComments\` option matches snapshot for a object value (no codition, extract only \`/@license/i\` comments): warnings 1`] = `Array []`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: chunks/4.4.a768ff21a59584840b5e.js 1`] = `
+"/*! For license information please see 4.4.a768ff21a59584840b5e.js.LICENSE */
+(window.webpackJsonp=window.webpackJsonp||[]).push([[4],{4:function(n,o){n.exports=Math.random()}}]);"
+`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: chunks/4.4.a768ff21a59584840b5e.js.LICENSE 1`] = `
+"/*! Legal Comment */
+
+/** @license Copyright 2112 Moon. **/
+"
+`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: errors 1`] = `Array []`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: filename/four.a51029ee38b02246ba30.js 1`] = `
+"/*! For license information please see four.a51029ee38b02246ba30.js.LICENSE */
+!function(e){var t={};function r(n){if(t[n])return t[n].exports;var o=t[n]={i:n,l:!1,exports:{}};return e[n].call(o.exports,o,o.exports,r),o.l=!0,o.exports}r.m=e,r.c=t,r.d=function(e,t,n){r.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:n})},r.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},r.t=function(e,t){if(1&t&&(e=r(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var n=Object.create(null);if(r.r(n),Object.defineProperty(n,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var o in e)r.d(n,o,function(t){return e[t]}.bind(null,o));return n},r.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return r.d(t,\\"a\\",t),t},r.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},r.p=\\"\\",r(r.s=3)}({3:function(e,t){e.exports=Math.random()}});"
+`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: filename/four.a51029ee38b02246ba30.js.LICENSE 1`] = `
+"/**
+ * Duplicate comment in difference files.
+ * @license MIT
+ */
+"
+`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: filename/one.e5466f67949ca359f275.js 1`] = `
+"/*! For license information please see one.e5466f67949ca359f275.js.LICENSE */
+!function(e){function t(t){for(var r,o,u=t[0],i=t[1],a=0,l=[];a<u.length;a++)o=u[a],Object.prototype.hasOwnProperty.call(n,o)&&n[o]&&l.push(n[o][0]),n[o]=0;for(r in i)Object.prototype.hasOwnProperty.call(i,r)&&(e[r]=i[r]);for(c&&c(t);l.length;)l.shift()()}var r={},n={1:0};function o(t){if(r[t])return r[t].exports;var n=r[t]={i:t,l:!1,exports:{}};return e[t].call(n.exports,n,n.exports,o),n.l=!0,n.exports}o.e=function(e){var t=[],r=n[e];if(0!==r)if(r)t.push(r[2]);else{var u=new Promise(function(t,o){r=n[e]=[t,o]});t.push(r[2]=u);var i,a=document.createElement(\\"script\\");a.charset=\\"utf-8\\",a.timeout=120,o.nc&&a.setAttribute(\\"nonce\\",o.nc),a.src=function(e){return o.p+\\"chunks/\\"+e+\\".\\"+({}[e]||e)+\\".\\"+{4:\\"a768ff21a59584840b5e\\"}[e]+\\".js\\"}(e);var c=new Error;i=function(t){a.onerror=a.onload=null,clearTimeout(l);var r=n[e];if(0!==r){if(r){var o=t&&(\\"load\\"===t.type?\\"missing\\":t.type),u=t&&t.target&&t.target.src;c.message=\\"Loading chunk \\"+e+\\" failed.\\\\n(\\"+o+\\": \\"+u+\\")\\",c.name=\\"ChunkLoadError\\",c.type=o,c.request=u,r[1](c)}n[e]=void 0}};var l=setTimeout(function(){i({type:\\"timeout\\",target:a})},12e4);a.onerror=a.onload=i,document.head.appendChild(a)}return Promise.all(t)},o.m=e,o.c=r,o.d=function(e,t,r){o.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},o.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},o.t=function(e,t){if(1&t&&(e=o(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(o.r(r),Object.defineProperty(r,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var n in e)o.d(r,n,function(t){return e[t]}.bind(null,n));return r},o.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return o.d(t,\\"a\\",t),t},o.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},o.p=\\"\\",o.oe=function(e){throw console.error(e),e};var u=window.webpackJsonp=window.webpackJsonp||[],i=u.push.bind(u);u.push=t,u=u.slice();for(var a=0;a<u.length;a++)t(u[a]);var c=i;o(o.s=0)}([function(e,t,r){r.e(4).then(r.t.bind(null,4,7)),e.exports=Math.random()}]);"
+`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: filename/one.e5466f67949ca359f275.js.LICENSE 1`] = `
+"/*! Legal Comment */
+
+/**
+ * @preserve Copyright 2009 SomeThirdParty.
+ * Here is the full license text and copyright
+ * notice for this file. Note that the notice can span several
+ * lines and is only terminated by the closing star and slash:
+ */
+
+/**
+ * Utility functions for the foo package.
+ * @license Apache-2.0
+ */
+
+/*! Legal Foo */
+"
+`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: filename/three.97df6fa9df169616d269.js 1`] = `
+"/*! For license information please see three.97df6fa9df169616d269.js.LICENSE */
+!function(e){var t={};function r(n){if(t[n])return t[n].exports;var o=t[n]={i:n,l:!1,exports:{}};return e[n].call(o.exports,o,o.exports,r),o.l=!0,o.exports}r.m=e,r.c=t,r.d=function(e,t,n){r.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:n})},r.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},r.t=function(e,t){if(1&t&&(e=r(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var n=Object.create(null);if(r.r(n),Object.defineProperty(n,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var o in e)r.d(n,o,function(t){return e[t]}.bind(null,o));return n},r.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return r.d(t,\\"a\\",t),t},r.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},r.p=\\"\\",r(r.s=2)}({2:function(e,t){e.exports=Math.random()}});"
+`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: filename/three.97df6fa9df169616d269.js.LICENSE 1`] = `
+"/**
+ * Duplicate comment in same file.
+ * @license MIT
+ */
+
+/**
+ * Duplicate comment in difference files.
+ * @license MIT
+ */
+"
+`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: filename/two.c8f73e41372935d939d4.js 1`] = `
+"/*! For license information please see two.c8f73e41372935d939d4.js.LICENSE */
+!function(e){var t={};function r(n){if(t[n])return t[n].exports;var o=t[n]={i:n,l:!1,exports:{}};return e[n].call(o.exports,o,o.exports,r),o.l=!0,o.exports}r.m=e,r.c=t,r.d=function(e,t,n){r.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:n})},r.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},r.t=function(e,t){if(1&t&&(e=r(e)),8&t)return e;if(4&t&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var n=Object.create(null);if(r.r(n),Object.defineProperty(n,\\"default\\",{enumerable:!0,value:e}),2&t&&\\"string\\"!=typeof e)for(var o in e)r.d(n,o,function(t){return e[t]}.bind(null,o));return n},r.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return r.d(t,\\"a\\",t),t},r.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},r.p=\\"\\",r(r.s=1)}([,function(e,t){e.exports=Math.random()}]);"
+`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: filename/two.c8f73e41372935d939d4.js.LICENSE 1`] = `
+"/**
+ * Information.
+ * @license MIT
+ */
+"
+`;
+
+exports[`when applied with \`extractComments\` option matches snapshot for a object value with "true" for the "condition" option: warnings 1`] = `Array []`;
 
 exports[`when applied with \`extractComments\` option matches snapshot when is not specify: chunks/4.4.41ddeb9cc3fd488974ca.js 1`] = `
 "(window.webpackJsonp=window.webpackJsonp||[]).push([[4],{4:function(n,o){

--- a/test/extractComments-option.test.js
+++ b/test/extractComments-option.test.js
@@ -180,6 +180,30 @@ describe('when applied with `extractComments` option', () => {
     });
   });
 
+  it('matches snapshot for a object value with "true" for the "condition" option', () => {
+    new TerserPlugin({
+      extractComments: {
+        condition: true,
+      },
+    }).apply(compiler);
+
+    return compile(compiler).then((stats) => {
+      const errors = stats.compilation.errors.map(cleanErrorStack);
+      const warnings = stats.compilation.warnings.map(cleanErrorStack);
+
+      expect(errors).toMatchSnapshot('errors');
+      expect(warnings).toMatchSnapshot('warnings');
+
+      for (const file in stats.compilation.assets) {
+        if (
+          Object.prototype.hasOwnProperty.call(stats.compilation.assets, file)
+        ) {
+          expect(stats.compilation.assets[file].source()).toMatchSnapshot(file);
+        }
+      }
+    });
+  });
+
   it('matches snapshot for a object value (extracts comments to multiple files)', () => {
     new TerserPlugin({
       extractComments: {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #20

### Breaking Changes

Yes

BREAKING CHANGE: using the `extractComments.condition` option with `true` value extract only `some` comments

### Additional Info


No