### PR TITLE
fix: revert do not run parallel mode when you have only one file

### DIFF
--- a/src/TaskRunner.js
+++ b/src/TaskRunner.js
@@ -41,7 +41,7 @@ export default class TaskRunner {
   }
 
   async run(tasks) {
-    if (this.numberWorkers > 1 && tasks.length > 1) {
+    if (this.numberWorkers > 1) {
       this.worker = new Worker(workerPath, { numWorkers: this.numberWorkers });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -262,18 +262,18 @@ class TerserPlugin {
           }
         });
 
-      let completedTasks = [];
-
-      if (tasks.length > 0) {
-        const taskRunner = new TaskRunner({
-          cache: this.options.cache,
-          parallel: this.options.parallel,
-        });
-
-        completedTasks = await taskRunner.run(tasks);
-
-        await taskRunner.exit();
+      if (tasks.length === 0) {
+        return Promise.resolve();
       }
+
+      const taskRunner = new TaskRunner({
+        cache: this.options.cache,
+        parallel: this.options.parallel,
+      });
+
+      const completedTasks = await taskRunner.run(tasks);
+
+      await taskRunner.exit();
 
       completedTasks.forEach((completedTask, index) => {
         const { file, input, inputSourceMap, commentsFile } = tasks[index];

--- a/test/parallel-option.test.js
+++ b/test/parallel-option.test.js
@@ -154,7 +154,14 @@ describe('parallel option', () => {
     const errors = stats.compilation.errors.map(cleanErrorStack);
     const warnings = stats.compilation.warnings.map(cleanErrorStack);
 
-    expect(Worker).toHaveBeenCalledTimes(0);
+    expect(Worker).toHaveBeenCalledTimes(1);
+    expect(Worker).toHaveBeenLastCalledWith(workerPath, {
+      numWorkers: os.cpus().length - 1,
+    });
+    expect(workerTransform).toHaveBeenCalledTimes(
+      Object.keys(stats.compilation.assets).length
+    );
+    expect(workerEnd).toHaveBeenCalledTimes(1);
 
     expect(errors).toMatchSnapshot('errors');
     expect(warnings).toMatchSnapshot('warnings');


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Revert, this often leads to memory overflow, so it is best to always use an external process

### Breaking Changes

No

### Additional Info

No