### PR TITLE
chore(defaults):  drop node 8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
     pool:
       vmImage: ubuntu-latest
     strategy:
-      maxParallel: 5
+      maxParallel: 4
       matrix:
         node-13:
           node_version: ^13.0.0
@@ -51,9 +51,6 @@ jobs:
           webpack_version: latest
         node-10:
           node_version: ^10.13.0
-          webpack_version: latest
-        node-8:
-          node_version: ^8.9.0
           webpack_version: latest
         node-10-canary:
           node_version: ^10.13.0
@@ -97,7 +94,7 @@ jobs:
     pool:
       vmImage: macOS-latest
     strategy:
-      maxParallel: 5
+      maxParallel: 4
       matrix:
         node-13:
           node_version: ^13.0.0
@@ -107,9 +104,6 @@ jobs:
           webpack_version: latest
         node-10:
           node_version: ^10.13.0
-          webpack_version: latest
-        node-8:
-          node_version: ^8.9.0
           webpack_version: latest
         node-10-canary:
           node_version: ^10.13.0
@@ -153,7 +147,7 @@ jobs:
     pool:
       vmImage: windows-latest
     strategy:
-      maxParallel: 5
+      maxParallel: 4
       matrix:
         node-13:
           node_version: ^13.0.0
@@ -163,9 +157,6 @@ jobs:
           webpack_version: latest
         node-10:
           node_version: ^10.13.0
-          webpack_version: latest
-        node-8:
-          node_version: ^8.9.0
           webpack_version: latest
         node-10-canary:
           node_version: ^10.13.0

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,7 @@ module.exports = (api) => {
         '@babel/preset-env',
         {
           targets: {
-            node: '8.9.0',
+            node: '10.13.0',
           },
         },
       ],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "dist/cjs.js",
   "engines": {
-    "node": ">= 8.9.0"
+    "node": ">= 10.13.0"
   },
   "scripts": {
     "start": "npm run build -- -w",


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

![](https://raw.githubusercontent.com/nodejs/Release/master/schedule.svg?sanitize=true)

```
The Node.js 8.x Maintenance LTS cycle will expire on December 31, 2019 
- which means that Node 8 won’t get any more updates, bug fixes or security patches.
```
https://blog.risingstack.com/update-nodejs-8-end-of-life-no-support/

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

Yes.

BREAKING CHANGE: minimum require Node.js version is 10.13.0

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

No
