### PR TITLE
Reduce memory overhead for webpack configs with many entries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -184,13 +184,7 @@ class TerserPlugin {
   }
 
   static hasAsset(commentFilename, assets) {
-    const assetFilenames = Object.keys(assets).map((assetFilename) =>
-      TerserPlugin.removeQueryString(assetFilename)
-    );
-
-    return assetFilenames.includes(
-      TerserPlugin.removeQueryString(commentFilename)
-    );
+    return assets.has(TerserPlugin.removeQueryString(commentFilename));
   }
 
   static isWebpack4() {
@@ -198,6 +192,12 @@ class TerserPlugin {
   }
 
   generateTasks(compiler, compilation, chunks, processedAssets) {
+    const existingAssets = new Set(
+      Object.keys(compilation.assets).map((assetFilename) =>
+        TerserPlugin.removeQueryString(assetFilename)
+      )
+    );
+
     const matchObject = ModuleFilenameHelpers.matchObject.bind(
       // eslint-disable-next-line no-undefined
       undefined,
@@ -290,7 +290,7 @@ class TerserPlugin {
 
         if (
           commentsFilename &&
-          TerserPlugin.hasAsset(commentsFilename, compilation.assets)
+          TerserPlugin.hasAsset(commentsFilename, existingAssets)
         ) {
           // Todo make error and stop uglifing in next major release
           compilation.warnings.push(

--- a/src/index.js
+++ b/src/index.js
@@ -197,6 +197,164 @@ class TerserPlugin {
     return webpackVersion[0] === '4';
   }
 
+  generateTasks(compiler, compilation, chunks, processedAssets) {
+    const matchObject = ModuleFilenameHelpers.matchObject.bind(
+      // eslint-disable-next-line no-undefined
+      undefined,
+      this.options
+    );
+    const additionalChunkAssets = Array.from(
+      compilation.additionalChunkAssets || []
+    );
+    const filteredChunks = Array.from(chunks).filter(
+      (chunk) => this.options.chunkFilter && this.options.chunkFilter(chunk)
+    );
+    const chunksFiles = filteredChunks.reduce(
+      (acc, chunk) => acc.concat(Array.from(chunk.files || [])),
+      []
+    );
+    const files = [].concat(additionalChunkAssets).concat(chunksFiles);
+
+    const tasks = [];
+
+    files.forEach((file) => {
+      if (!matchObject(file)) {
+        return;
+      }
+
+      let inputSourceMap;
+
+      const asset = compilation.assets[file];
+
+      if (processedAssets.has(asset)) {
+        return;
+      }
+
+      try {
+        let input;
+
+        if (this.options.sourceMap && asset.sourceAndMap) {
+          const { source, map } = asset.sourceAndMap();
+
+          input = source;
+
+          if (TerserPlugin.isSourceMap(map)) {
+            inputSourceMap = map;
+          } else {
+            inputSourceMap = map;
+
+            compilation.warnings.push(
+              new Error(`${file} contains invalid source map`)
+            );
+          }
+        } else {
+          input = asset.source();
+          inputSourceMap = null;
+        }
+
+        // Handling comment extraction
+        let commentsFilename = false;
+
+        if (this.options.extractComments) {
+          commentsFilename =
+            this.options.extractComments.filename || '[file].LICENSE[query]';
+
+          if (TerserPlugin.isWebpack4()) {
+            // Todo remove this in next major release
+            if (typeof commentsFilename === 'function') {
+              commentsFilename = commentsFilename.bind(null, file);
+            }
+          }
+
+          let query = '';
+          let filename = file;
+
+          const querySplit = filename.indexOf('?');
+
+          if (querySplit >= 0) {
+            query = filename.substr(querySplit);
+            filename = filename.substr(0, querySplit);
+          }
+
+          const lastSlashIndex = filename.lastIndexOf('/');
+
+          const basename =
+            lastSlashIndex === -1
+              ? filename
+              : filename.substr(lastSlashIndex + 1);
+
+          const data = { filename, basename, query };
+
+          commentsFilename = compilation.getPath(commentsFilename, data);
+        }
+
+        if (
+          commentsFilename &&
+          TerserPlugin.hasAsset(commentsFilename, compilation.assets)
+        ) {
+          // Todo make error and stop uglifing in next major release
+          compilation.warnings.push(
+            new Error(
+              `The comment file "${TerserPlugin.removeQueryString(
+                commentsFilename
+              )}" conflicts with an existing asset, this may lead to code corruption, please use a different name`
+            )
+          );
+        }
+
+        const task = {
+          asset,
+          file,
+          input,
+          inputSourceMap,
+          commentsFilename,
+          extractComments: this.options.extractComments,
+          terserOptions: this.options.terserOptions,
+          minify: this.options.minify,
+        };
+
+        if (TerserPlugin.isWebpack4()) {
+          if (this.options.cache) {
+            const defaultCacheKeys = {
+              terser: terserPackageJson.version,
+              // eslint-disable-next-line global-require
+              'terser-webpack-plugin': require('../package.json').version,
+              'terser-webpack-plugin-options': this.options,
+              nodeVersion: process.version,
+              filename: file,
+              contentHash: crypto
+                .createHash('md4')
+                .update(input)
+                .digest('hex'),
+            };
+
+            task.cacheKeys = this.options.cacheKeys(defaultCacheKeys, file);
+          }
+        } else {
+          task.cacheKeys = {
+            terser: terserPackageJson.version,
+            // eslint-disable-next-line global-require
+            'terser-webpack-plugin': require('../package.json').version,
+            'terser-webpack-plugin-options': this.options,
+          };
+        }
+
+        tasks.push(task);
+      } catch (error) {
+        compilation.errors.push(
+          TerserPlugin.buildError(
+            error,
+            file,
+            TerserPlugin.buildSourceMap(inputSourceMap),
+            new RequestShortener(compiler.context)
+          )
+        );
+      }
+    });
+
+    return tasks;
+  }
+
   apply(compiler) {
     const { devtool, output, plugins } = compiler.options;
 
@@ -233,158 +391,12 @@ class TerserPlugin {
 
     const optimizeFn = async (compilation, chunks) => {
       const processedAssets = new WeakSet();
-      const matchObject = ModuleFilenameHelpers.matchObject.bind(
-        // eslint-disable-next-line no-undefined
-        undefined,
-        this.options
+      const tasks = this.generateTasks(
+        compiler,
+        compilation,
+        chunks,
+        processedAssets
       );
-      const additionalChunkAssets = Array.from(
-        compilation.additionalChunkAssets || []
-      );
-      const filteredChunks = Array.from(chunks).filter(
-        (chunk) => this.options.chunkFilter && this.options.chunkFilter(chunk)
-      );
-      const chunksFiles = filteredChunks.reduce(
-        (acc, chunk) => acc.concat(Array.from(chunk.files || [])),
-        []
-      );
-      const files = [].concat(additionalChunkAssets).concat(chunksFiles);
-      const tasks = [];
-
-      files.forEach((file) => {
-        if (!matchObject(file)) {
-          return;
-        }
-
-        let inputSourceMap;
-
-        const asset = compilation.assets[file];
-
-        if (processedAssets.has(asset)) {
-          return;
-        }
-
-        try {
-          let input;
-
-          if (this.options.sourceMap && asset.sourceAndMap) {
-            const { source, map } = asset.sourceAndMap();
-
-            input = source;
-
-            if (TerserPlugin.isSourceMap(map)) {
-              inputSourceMap = map;
-            } else {
-              inputSourceMap = map;
-
-              compilation.warnings.push(
-                new Error(`${file} contains invalid source map`)
-              );
-            }
-          } else {
-            input = asset.source();
-            inputSourceMap = null;
-          }
-
-          // Handling comment extraction
-          let commentsFilename = false;
-
-          if (this.options.extractComments) {
-            commentsFilename =
-              this.options.extractComments.filename || '[file].LICENSE[query]';
-
-            if (TerserPlugin.isWebpack4()) {
-              // Todo remove this in next major release
-              if (typeof commentsFilename === 'function') {
-                commentsFilename = commentsFilename.bind(null, file);
-              }
-            }
-
-            let query = '';
-            let filename = file;
-
-            const querySplit = filename.indexOf('?');
-
-            if (querySplit >= 0) {
-              query = filename.substr(querySplit);
-              filename = filename.substr(0, querySplit);
-            }
-
-            const lastSlashIndex = filename.lastIndexOf('/');
-
-            const basename =
-              lastSlashIndex === -1
-                ? filename
-                : filename.substr(lastSlashIndex + 1);
-
-            const data = { filename, basename, query };
-
-            commentsFilename = compilation.getPath(commentsFilename, data);
-          }
-
-          if (
-            commentsFilename &&
-            TerserPlugin.hasAsset(commentsFilename, compilation.assets)
-          ) {
-            // Todo make error and stop uglifing in next major release
-            compilation.warnings.push(
-              new Error(
-                `The comment file "${TerserPlugin.removeQueryString(
-                  commentsFilename
-                )}" conflicts with an existing asset, this may lead to code corruption, please use a different name`
-              )
-            );
-          }
-
-          const task = {
-            asset,
-            file,
-            input,
-            inputSourceMap,
-            commentsFilename,
-            extractComments: this.options.extractComments,
-            terserOptions: this.options.terserOptions,
-            minify: this.options.minify,
-          };
-
-          if (TerserPlugin.isWebpack4()) {
-            if (this.options.cache) {
-              const defaultCacheKeys = {
-                terser: terserPackageJson.version,
-                // eslint-disable-next-line global-require
-                'terser-webpack-plugin': require('../package.json').version,
-                'terser-webpack-plugin-options': this.options,
-                nodeVersion: process.version,
-                filename: file,
-                contentHash: crypto
-                  .createHash('md4')
-                  .update(input)
-                  .digest('hex'),
-              };
-
-              task.cacheKeys = this.options.cacheKeys(defaultCacheKeys, file);
-            }
-          } else {
-            task.cacheKeys = {
-              terser: terserPackageJson.version,
-              // eslint-disable-next-line global-require
-              'terser-webpack-plugin': require('../package.json').version,
-              'terser-webpack-plugin-options': this.options,
-            };
-          }
-
-          tasks.push(task);
-        } catch (error) {
-          compilation.errors.push(
-            TerserPlugin.buildError(
-              error,
-              file,
-              TerserPlugin.buildSourceMap(inputSourceMap),
-              new RequestShortener(compiler.context)
-            )
-          );
-        }
-      });
 
       if (tasks.length === 0) {
         return Promise.resolve();

--- a/src/index.js
+++ b/src/index.js
@@ -292,7 +292,7 @@ class TerserPlugin {
           commentsFilename &&
           TerserPlugin.hasAsset(commentsFilename, existingAssets)
         ) {
-          // Todo make error and stop uglifing in next major release
+          // Todo make error and stop uglifying in next major release
           compilation.warnings.push(
             new Error(
               `The comment file "${TerserPlugin.removeQueryString(


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This change dramatically reduces the total size of objects on the heap at any one time for webpack configurations with many entries. Because `tasks` used to be computed eagerly and `completedTasks` was collected as a large Array, space complexity used to be linear with respect to the number of entries. (More precisely, the max heap size was proportional to the combined size in bytes of all pre-minified sources).

Now, we defer the generation of a `task` (and thus the memory allocation required for computing `asset.source()` of an entry) until a worker is made available. Similarly, the computation of `serialize(task)`, another large String, is deferred until a worker is available. Finally, when a
`task` is completed, the `completedTask` is consumed immediately, releasing the reference to the original `asset.source()`, and making it a candidate for garbage collection.

The effect is that space complexity is now roughly linear with respect to the number of parallel workers. The number of pre-minified sources that are considered "live" to the garbage collector will never exceed the number of parallel workers.

I believe this fixes #143 for most people experiencing the problem.

I created a repository that reliably reproduces the issue: https://github.com/cjlarose/terser-webpack-plugin-out-of-memory. Using the changes introduced in this PR, that project builds successfully using the default Node old space size (1400MB).

### Breaking Changes

None

### Additional Info
