### PR TITLE
feat(defaults): default to 2 compression passes

### DIFF
--- a/src/minify.js
+++ b/src/minify.js
@@ -20,7 +20,13 @@ const buildTerserOptions = ({
   ecma,
   warnings,
   parse: { ...parse },
-  compress: typeof compress === 'boolean' ? compress : { ...compress },
+  compress:
+    typeof compress === 'boolean'
+      ? compress
+      : {
+        passes: 2,
+        ...compress
+      },
   // eslint-disable-next-line no-nested-ternary
   mangle:
     mangle == null


### PR DESCRIPTION
This PR contains a:

- [x] new **feature**

### Motivation / Use-Case

I'm hoping this provides a better alternative to webpack-contrib/mini-css-extract-plugin#509, which has some flaws that I don't think can be overcome. It would also be a generalized improvement for Webpack, rather than being specific to CSS Modules.

By default, `terser-webpack-plugin` runs Terser with the default `compress.passes=1`. This prevents Terser from inlining relatively common cases that would be covered if `passes` were increased to `2`.

### Example

The one I'm looking at right now is CSS Modules className mappings that get inlined into the module that imported them via ModuleConcatenation:

##### input:

```js
import styles from './style.css';
document.body.innerHTML = `
  <div class="${styles.foo}">
    <span class="${styles.bar}">hello</span>
  </div>
`;
```

##### raw output:

```js
[ function(e, t, n) {
    "use strict";
    n.r(t);
    var styles = ({
      "foo":"_1QXSp-vHE2lSYKI1zPJzRj",
      "bar":"_2HdeYqDJ0HpgTdR_Whcvls"
    });
    document.body.innerHTML = `
  <div class="${styles.foo}">
    <span class="${styles.bar}">hello</span>
  </div>
`;
} ]
```

##### output with `passes:1` _(current default)_

```js
[ function(e, t, n) {
    "use strict";
    n.r(t);
    var r = "_1QXSp-vHE2lSYKI1zPJzRj", o = "_2HdeYqDJ0HpgTdR_Whcvls";
    document.body.innerHTML = `
  <div class="${r}">
    <span class="${o}">hello</span>
  </div>
`;
} ]
```

##### output with `passes=2` _(proposed)_

```js
[ function(e, t, n) {
    "use strict";
    n.r(t);
    document.body.innerHTML = `
  <div class="_1QXSp-vHE2lSYKI1zPJzRj">
    <span class="_2HdeYqDJ0HpgTdR_Whcvls">hello</span>
  </div>
`;
} ]
```

### Breaking Changes

I don't believe increasing `passes` would constitute a breaking change, since Terser is already performing the same optimizations for syntax that did not require an initial pre-pass. That is to say - breaking objects apart into local variables is already happening, and inlining single-use locals is also already happening - just not currently in combination.
