### PR TITLE
refactor: `warningsFilter` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,13 +609,13 @@ module.exports = {
 
 ### `warningsFilter`
 
-Type: `Function<(warning, source, file) -> Boolean>`
+Type: `Function<(warning, file, source) -> Boolean>`
 Default: `() => true`
 
 Allow to filter [terser](https://github.com/terser-js/terser) warnings.
 Return `true` to keep the warning, a falsy value (`false`/`null`/`undefined`) otherwise.
 
-> ⚠️ The `source` argument will contain `undefined` if you don't use source maps.
+> ⚠️ The `source` argument will contain `null` if you don't use source maps.
 
 **webpack.config.js**
 
@@ -625,16 +625,16 @@ module.exports = {
     minimize: true,
     minimizer: [
       new TerserPlugin({
-        warningsFilter: (warning, source, file) => {
+        warningsFilter: (warning, file, source) => {
           if (/Dropping unreachable code/i.test(warning)) {
             return true;
           }
 
-          if (/source\.js/i.test(source)) {
+          if (/file\.js/i.test(file)) {
             return true;
           }
 
-          if (/file\.js/i.test(file)) {
+          if (/source\.js/i.test(source)) {
             return true;
           }
 

--- a/src/index.js
+++ b/src/index.js
@@ -159,8 +159,7 @@ class TerserPlugin {
       }
     }
 
-    // Todo change order in next major release
-    if (warningsFilter && !warningsFilter(warning, source, file)) {
+    if (warningsFilter && !warningsFilter(warning, file, source)) {
       return null;
     }
 

--- a/test/warningsFilter-option.test.js
+++ b/test/warningsFilter-option.test.js
@@ -71,7 +71,7 @@ describe('warningsFilter option', () => {
 
   it('should match snapshot for a "function" value and the "sourceMap" value is "true" (filter by source)', async () => {
     new TerserPlugin({
-      warningsFilter(warning, source) {
+      warningsFilter(warning, file, source) {
         if (/unreachable-code\.js/.test(source)) {
           return true;
         }
@@ -93,7 +93,7 @@ describe('warningsFilter option', () => {
 
   it('should match snapshot for a "function" value and the "sourceMap" option is "true" (filter by file)', async () => {
     new TerserPlugin({
-      warningsFilter(warning, source, file) {
+      warningsFilter(warning, file) {
         if (/two\.js/.test(file)) {
           return true;
         }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Better order of arguments

### Breaking Changes

Yes

BREAKING CHANGE: change arguments order for the `warningFilter` option from `Function<(warning, file, source) -> Boolean>` to `Function<(file, warning, source) -> Boolean>`

### Additional Info

No