### PR TITLE
Remove redundant chunkFilter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,6 @@ class TerserPlugin {
       minify,
       terserOptions = {},
       test = /\.m?js(\?.*)?$/i,
-      chunkFilter = () => true,
       warningsFilter = () => true,
       extractComments = true,
       sourceMap,
@@ -47,7 +46,6 @@ class TerserPlugin {
 
     this.options = {
       test,
-      chunkFilter,
       warningsFilter,
       extractComments,
       sourceMap,


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

If plugin uses minimize options from `compiler.optimization`, it will fail because of default terser plugin options object. Field `chunkFilter` is not allowed, but it contains in default options object.
Example: https://github.com/NekR/offline-plugin/blob/66cde2c7784b5be8c84fecbb93c6f9f96faacdb5/src/service-worker.js#L106

As i see, `chunkFilter` never uses in plugin, so it can be removed easily.

Minimal repo to reproduce:
https://github.com/Dekkee/terser-bug

### Breaking Changes

no breaking changes according to 3.0.0 release
