### PR TITLE
chore(webpack5cache): use compilation.getCache() instead of compilation.cache

### DIFF
--- a/src/Webpack5Cache.js
+++ b/src/Webpack5Cache.js
@@ -11,7 +11,7 @@ export default class Cache {
   }
 
   isEnabled() {
-    return Boolean(this.compilation.cache);
+    return Boolean(this.compilation.getCache());
   }
 
   createCacheIdent(task) {


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Whilst running webpack 5's integration tests I noticed that this plugin was outputting 

```
(node:63176) [DEP_WEBPACK_COMPILATION_CACHE] DeprecationWarning: Compilation.cache was removed in favor of Compilation.getCache()
    at Cache.isEnabled (/Users/ryan/code/webpack/node_modules/terser-webpack-plugin/dist/Webpack5Cache.js:24:37)
```

So this is just a small PR to fix that deprecation warning.

### Breaking Changes

N/A