### PR TITLE
chore(webpack5cache): use compilation.getCache() instead of compilation.cache

### DIFF
--- a/src/Webpack5Cache.js
+++ b/src/Webpack5Cache.js
@@ -11,7 +11,7 @@ export default class Cache {
   }
 
   isEnabled() {
-    return Boolean(this.compilation.cache);
+    return Boolean(this.compilation.getCache());
   }
 
   createCacheIdent(task) {


### PR DESCRIPTION
Rerunning CI for #277 to make sure it passes now.

Edit: looks like the latest webpack version changed the output quite a bit, assuming because of the tree shaking changes. I guess @evilebottnawi will want to update the snapshots 👍 