### PR TITLE
No need to install it if you use webpack v4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This plugin uses [terser](https://github.com/terser-js/terser) to minify your Ja
 
 ## Getting Started
 
+If you are using webpack v5 or above you do not need to install this plugin. Webpack v5 comes with the latest `terser-webpack-plugin` out of the box.
+
 To begin, you'll need to install `terser-webpack-plugin`:
 
 ```console


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Some people still install and set up this plugin in their webpack explicitly. The proposed line in the readme is supposed to make it easier for the newcomers.

### Breaking Changes

none

### Additional Info
