### PR TITLE
feat: add chunkFilter option

### DIFF
--- a/src/options.json
+++ b/src/options.json
@@ -61,6 +61,15 @@
         }
       ]
     },
+    "chunkFilter": {
+      "description": "A function of type (chunk: Chunk | undefined, fileName: string) => boolean.",
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "instanceof": "Function"
+        }
+      ]
+    },
     "terserOptions": {
       "description": "Options for `terser`.",
       "additionalProperties": true,

--- a/test/__snapshots__/chunk-filter-option.test.js.snap
+++ b/test/__snapshots__/chunk-filter-option.test.js.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`chunk filter option should match snapshot for a chunk filter that only includes one chunk: assets 1`] = `
+Object {
+  "dontInclude.js": "/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 993:
+/***/ ((module) => {
+
+module.exports = \\"ok\\";
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		if(__webpack_module_cache__[moduleId]) {
+/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	// startup
+/******/ 	// Load entry module
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	__webpack_require__(993);
+/******/ })()
+;",
+  "include.js": "(()=>{var r={791:r=>{r.exports=function(){console.log(7)}}},o={};!function t(e){if(o[e])return o[e].exports;var n=o[e]={exports:{}};return r[e](n,n.exports,t),n.exports}(791)})();",
+}
+`;
+
+exports[`chunk filter option should match snapshot for a chunk filter that only includes one chunk: errors 1`] = `Array []`;
+
+exports[`chunk filter option should match snapshot for a chunk filter that only includes one chunk: warnings 1`] = `Array []`;
+
+exports[`chunk filter option should match snapshot with empty value: assets 1`] = `
+Object {
+  "dontInclude.js": "(()=>{var r={993:r=>{r.exports=\\"ok\\"}},t={};!function e(o){if(t[o])return t[o].exports;var p=t[o]={exports:{}};return r[o](p,p.exports,e),p.exports}(993)})();",
+  "include.js": "(()=>{var r={791:r=>{r.exports=function(){console.log(7)}}},o={};!function t(e){if(o[e])return o[e].exports;var n=o[e]={exports:{}};return r[e](n,n.exports,t),n.exports}(791)})();",
+}
+`;
+
+exports[`chunk filter option should match snapshot with empty value: errors 1`] = `Array []`;
+
+exports[`chunk filter option should match snapshot with empty value: warnings 1`] = `Array []`;

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -174,5 +174,5 @@ exports[`validation 14`] = `
 exports[`validation 15`] = `
 "Invalid options object. Terser Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { test?, include?, exclude?, terserOptions?, extractComments?, parallel?, minify? }"
+   object { test?, include?, exclude?, chunkFilter?, terserOptions?, extractComments?, parallel?, minify? }"
 `;

--- a/test/chunk-filter-option.test.js
+++ b/test/chunk-filter-option.test.js
@@ -1,0 +1,60 @@
+import path from "path";
+
+import TerserPlugin from "../src/index";
+
+import {
+  compile,
+  getCompiler,
+  getErrors,
+  getWarnings,
+  readsAssets,
+} from "./helpers";
+
+describe("chunk filter option", () => {
+  let compiler;
+
+  beforeEach(() => {
+    compiler = getCompiler({
+      entry: {
+        include: path.resolve(__dirname, "./fixtures/entry.js"),
+        dontInclude: path.resolve(__dirname, "./fixtures/file.js"),
+      },
+      output: {
+        path: path.resolve(__dirname, "./dist"),
+        filename: `[name].js`,
+        chunkFilename: `[id].[name].js`,
+      },
+    });
+  });
+
+  it("should match snapshot with empty value", async () => {
+    new TerserPlugin().apply(compiler);
+
+    const stats = await compile(compiler);
+
+    expect(readsAssets(compiler, stats)).toMatchSnapshot("assets");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+  });
+
+  it("should match snapshot for a chunk filter that only includes one chunk", async () => {
+    const chunkFilter = jest.fn((chunk) => chunk.name === "include");
+    new TerserPlugin({
+      chunkFilter: (chunk, name) => chunkFilter(chunk, name),
+    }).apply(compiler);
+
+    const stats = await compile(compiler);
+
+    expect(chunkFilter).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "include" }),
+      "include.js"
+    );
+    expect(chunkFilter).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "dontInclude" }),
+      "dontInclude.js"
+    );
+    expect(readsAssets(compiler, stats)).toMatchSnapshot("assets");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+  });
+});


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

We do not tag our vendor assets with a `.vendor.js` postfix, so when the terser plugin runs the `test|include|option` it only sees the generated hash name and has no way to filter out the vendor chunks.

Conditionally naming our assets just so they can be filtered in the plugin adds complexity to our build configuration, and leaks unnecessary information.

By re-adding the `chunkFilter` option, we can filter the assets on their non-hashed non-public chunk name.

Thanks!

### Breaking Changes

None

### Additional Info


https://github.com/webpack-contrib/terser-webpack-plugin/issues/361
