### PR TITLE
doc: webpack v4 needs terser v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ This plugin uses [terser](https://github.com/terser-js/terser) to minify your Ja
 
 If you are using webpack v5 or above you do not need to install this plugin. Webpack v5 comes with the latest `terser-webpack-plugin` out of the box.
 
-To begin, you'll need to install `terser-webpack-plugin`:
+To begin when using webpack v4, you'll need to install `terser-webpack-plugin`:
 
 ```console
-$ npm install terser-webpack-plugin --save-dev
+$ npm install terser-webpack-plugin@4 --save-dev
 ```
 
 Then add the plugin to your `webpack` config. For example:

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ This plugin uses [terser](https://github.com/terser-js/terser) to minify your Ja
 
 ## Getting Started
 
-If you are using webpack v5 or above you do not need to install this plugin. Webpack v5 comes with the latest `terser-webpack-plugin` out of the box.
+If you are using webpack v5 or above you do not need to install this plugin. Webpack v5 comes with the latest `terser-webpack-plugin` out of the box. Using Webpack v4, you have to install terser-webpack-plugin v4.
 
-To begin when using webpack v4, you'll need to install `terser-webpack-plugin`:
+To begin, you'll need to install `terser-webpack-plugin`:
 
 ```console
-$ npm install terser-webpack-plugin@4 --save-dev
+$ npm install terser-webpack-plugin --save-dev
 ```
 
 Then add the plugin to your `webpack` config. For example:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This plugin uses [terser](https://github.com/terser-js/terser) to minify your Ja
 
 ## Getting Started
 
-If you are using webpack v5 or above you do not need to install this plugin. Webpack v5 comes with the latest `terser-webpack-plugin` out of the box. Using Webpack v4, you have to install terser-webpack-plugin v4.
+If you are using webpack v5 or above you do not need to install this plugin. Webpack v5 comes with the latest `terser-webpack-plugin` out of the box. Using Webpack v4, you have to install `terser-webpack-plugin` v4.
 
 To begin, you'll need to install `terser-webpack-plugin`:
 


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**
- [x] A doc improvement

### Motivation / Use-Case

Many peoples seems upset because they failed to install this lib with webpack 4: https://github.com/webpack-contrib/terser-webpack-plugin/issues/335#issuecomment-709997726. Since "Webpack v5 comes with the latest terser-webpack-plugin out of the box", **the only users that want to install it manually would be the one that use v4**. I guess people would be more happy with this hint.

Scenario: I did not know terser and had to improve a webpack (v4) config file. I read that I have to replace uglify plugin which is not maintained with terser. So I went to this repo and copy/pasted the install line as stated in the readme. It failed.

Feel free to ask me anything, I would be super happy to improve my PR!