### PR TITLE
Refactor types

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,16 +676,39 @@ module.exports = {
 With built-in minify functions:
 
 ```ts
-import type { JsMinifyOptions } from "@swc/core";
+import type { JsMinifyOptions as SwcOptions } from "@swc/core";
+import type { MinifyOptions as UglifyJSOptions } from "uglify-js";
+import type { TransformOptions as EsbuildOptions } from "esbuild";
+import type { MinifyOptions as TerserOptions } from "terser";
 
 module.exports = {
   optimization: {
     minimize: true,
     minimizer: [
-      new TerserPlugin<JsMinifyOptions>({
+      new TerserPlugin<SwcOptions>({
         minify: TerserPlugin.swcMinify,
         terserOptions: {
-          compress: true,
+          // `swc` options
+        },
+      }),
+      new TerserPlugin<UglifyJSOptions>({
+        minify: TerserPlugin.uglifyJsMinify,
+        terserOptions: {
+          // `uglif-js` options
+        },
+      }),
+      new TerserPlugin<EsbuildOptions>({
+        minify: TerserPlugin.esbuildMinify,
+        terserOptions: {
+          // `esbuild` options
+        },
+      }),
+
+      // Alternative usage:
+      new TerserPlugin<TerserOptions>({
+        minify: TerserPlugin.terserMinify,
+        terserOptions: {
+          // `terser` options
         },
       }),
     ],

--- a/README.md
+++ b/README.md
@@ -676,21 +676,13 @@ module.exports = {
 With built-in minify functions:
 
 ```ts
-import type { SwcMinifyFunction } from "terser-webpack-plugin";
+import type { JsMinifyOptions } from "@swc/core";
 
 module.exports = {
   optimization: {
     minimize: true,
     minimizer: [
-      new TerserPlugin<SwcMinimizer>({
-        minify: TerserPlugin.swcMinify,
-        terserOptions: {
-          compress: true,
-        },
-      }),
-
-      // Alternative:
-      new TerserPlugin<typeof TerserPlugin.swcMinify>({
+      new TerserPlugin<JsMinifyOptions>({
         minify: TerserPlugin.swcMinify,
         terserOptions: {
           compress: true,

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ import { minify as minimize } from "./minify";
 
 /**
  * @template T
- * @typedef {{ minify?: MinimizerImplementation<InferDefault<T>> | undefined, terserOptions?: InferDefault<T> | undefined}} DefinedDefaultMinimizerAndOptions
+ * @typedef {InferDefault<T> extends TerserOptions ? { minify?: MinimizerImplementation<InferDefault<T>> | undefined, terserOptions?: InferDefault<T> | undefined } : { minify: MinimizerImplementation<InferDefault<T>>, terserOptions?: InferDefault<T> | undefined }} DefinedDefaultMinimizerAndOptions
  */
 
 // TODO please add manually `T = TerserOptions`, because typescript is not supported default value for templates yet

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,7 @@ import { minify as minimize } from "./minify";
 /** @typedef {import("webpack").Asset} Asset */
 /** @typedef {import("./utils.js").TerserECMA} TerserECMA */
 /** @typedef {import("./utils.js").TerserOptions} TerserOptions */
-/** @typedef {import("./utils.js").UglifyJSOptions} UglifyJSOptions */
-/** @typedef {import("./utils.js").SwcOptions} SwcOptions */
-/** @typedef {import("./utils.js").EsbuildOptions} EsbuildOptions */
-/** @typedef {Object.<any, any>} CustomOptions */
+/** @typedef {import("./utils.js").CustomOptions} CustomOptions */
 /** @typedef {import("jest-worker").Worker} JestWorker */
 /** @typedef {import("source-map").RawSourceMap} RawSourceMap */
 
@@ -81,14 +78,14 @@ import { minify as minimize } from "./minify";
 /**
  * @typedef {Object} PredefinedOptions
  * @property {boolean} [module]
- * @property {5 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020 | number | string} [ecma]
+ * @property {any} [ecma]
  */
 
 /**
  * @template T
  * @typedef {Object} MinimizerImplementationAndOptions
- * @property {MinimizerImplementation<ThirdArgument<T>>} implementation
- * @property {PredefinedOptions & ThirdArgument<T>} options
+ * @property {MinimizerImplementation<T>} implementation
+ * @property {PredefinedOptions & T} options
  */
 
 /**
@@ -127,26 +124,6 @@ import { minify as minimize } from "./minify";
  */
 
 /**
- * @typedef {MinimizerImplementation<TerserOptions>} TerserMinimizer
- */
-
-/**
- * @typedef {MinimizerImplementation<UglifyJSOptions>} UglifyJSMinimizer
- */
-
-/**
- * @typedef {MinimizerImplementation<SwcOptions>} SwcMinimizer
- */
-
-/**
- * @typedef {MinimizerImplementation<EsbuildOptions>} EsbuildMinimizer
- */
-
-/**
- * @typedef {MinimizerImplementation<CustomOptions>} CustomMinimizer
- */
-
-/**
  * @typedef {Object} BasePluginOptions
  * @property {Rules} [test]
  * @property {Rules} [include]
@@ -157,28 +134,21 @@ import { minify as minimize } from "./minify";
 
 /**
  * @template T
- * @typedef {T extends (arg1: any, arg2: any, arg3: infer U, ...args: any[]) => any ? U: never} ThirdArgument
+ * @typedef {T extends infer U ? U : CustomOptions} InferDefault
  */
 
 /**
  * @template T
- * @typedef {Object} DefaultMinimizerImplementationAndOptions
- * @property {undefined | MinimizerImplementation<ThirdArgument<T>>} [minify]
- * @property {ThirdArgument<T> | undefined} [terserOptions]
+ * @typedef {{ minify?: MinimizerImplementation<InferDefault<T>> | undefined, terserOptions?: InferDefault<T> | undefined}} DefinedDefaultMinimizerAndOptions
  */
 
+// TODO please add manually `T = TerserOptions`, because typescript is not supported default value for templates yet
 /**
  * @template T
- * @typedef {T extends MinimizerImplementation<TerserOptions> ? DefaultMinimizerImplementationAndOptions<T> : { minify: MinimizerImplementation<ThirdArgument<T>>, terserOptions?: ThirdArgument<T> | undefined}} PickMinimizerImplementationAndOptions
- */
-
-// TODO please add manually `T extends ... = TerserMinimizer`, because typescript is not supported default value for templates yet
-/**
- * @template {TerserMinimizer | UglifyJSMinimizer | SwcMinimizer | EsbuildMinimizer | CustomMinimizer} T=TerserMinimizer
  */
 class TerserPlugin {
   /**
-   * @param {BasePluginOptions & PickMinimizerImplementationAndOptions<T>} [options]
+   * @param {BasePluginOptions & DefinedDefaultMinimizerAndOptions<T>} [options]
    */
   constructor(options) {
     validate(/** @type {Schema} */ (schema), options || {}, {
@@ -186,9 +156,12 @@ class TerserPlugin {
       baseDataPath: "options",
     });
 
+    // TODO make `minimizer` option instead `minify` and `terserOptions` in the next major release, also rename `terserMinify` to `terserMinimize`
     const {
-      minify = terserMinify,
-      terserOptions = {},
+      minify = /** @type {MinimizerImplementation<InferDefault<T>>} */ (
+        terserMinify
+      ),
+      terserOptions = /** @type {InferDefault<T>} */ ({}),
       test = /\.[cm]?js(\?.*)?$/i,
       extractComments = true,
       parallel = true,
@@ -196,17 +169,16 @@ class TerserPlugin {
       exclude,
     } = options || {};
 
-    /**
-     * @type {BasePluginOptions & { minify: MinimizerImplementation<ThirdArgument<T>>, terserOptions: ThirdArgument<T>}}
-     */
     this.options = {
       test,
       extractComments,
       parallel,
       include,
       exclude,
-      minify,
-      terserOptions,
+      minimizer: {
+        implementation: minify,
+        options: terserOptions,
+      },
     };
   }
 
@@ -494,17 +466,14 @@ class TerserPlugin {
               input = input.toString();
             }
 
-            /** @type {InternalOptions<T>} */
             const options = {
               name,
               input,
               inputSourceMap,
-              // TODO make `minimizer` option instead `minify` and `terserOptions` in the next major release, also rename `terserMinify` to `terserMinimize`
               minimizer: {
-                implementation: this.options.minify,
-                options: {
-                  ...this.options.terserOptions,
-                },
+                implementation: this.options.minimizer.implementation,
+                // @ts-ignore https://github.com/Microsoft/TypeScript/issues/10727
+                options: { ...this.options.minimizer.options },
               },
               extractComments: this.options.extractComments,
             };
@@ -865,10 +834,12 @@ class TerserPlugin {
         );
       const data = serialize({
         minimizer:
-          typeof this.options.minify.getMinimizerVersion !== "undefined"
-            ? this.options.minify.getMinimizerVersion() || "0.0.0"
+          typeof this.options.minimizer.implementation.getMinimizerVersion !==
+          "undefined"
+            ? this.options.minimizer.implementation.getMinimizerVersion() ||
+              "0.0.0"
             : "0.0.0",
-        options: this.options.terserOptions,
+        options: this.options.minimizer.options,
       });
 
       hooks.chunkHash.tap(pluginName, (chunk, hash) => {

--- a/src/index.js
+++ b/src/index.js
@@ -134,12 +134,12 @@ import { minify as minimize } from "./minify";
 
 /**
  * @template T
- * @typedef {T extends infer U ? U : CustomOptions} InferDefault
+ * @typedef {T extends infer U ? U : CustomOptions} InferDefaultType
  */
 
 /**
  * @template T
- * @typedef {InferDefault<T> extends TerserOptions ? { minify?: MinimizerImplementation<InferDefault<T>> | undefined, terserOptions?: InferDefault<T> | undefined } : { minify: MinimizerImplementation<InferDefault<T>>, terserOptions?: InferDefault<T> | undefined }} DefinedDefaultMinimizerAndOptions
+ * @typedef {InferDefaultType<T> extends TerserOptions ? { minify?: MinimizerImplementation<InferDefaultType<T>> | undefined, terserOptions?: InferDefaultType<T> | undefined } : { minify: MinimizerImplementation<InferDefaultType<T>>, terserOptions?: InferDefaultType<T> | undefined }} DefinedDefaultMinimizerAndOptions
  */
 
 // TODO please add manually `T = TerserOptions`, because typescript is not supported default value for templates yet
@@ -158,10 +158,10 @@ class TerserPlugin {
 
     // TODO make `minimizer` option instead `minify` and `terserOptions` in the next major release, also rename `terserMinify` to `terserMinimize`
     const {
-      minify = /** @type {MinimizerImplementation<InferDefault<T>>} */ (
+      minify = /** @type {MinimizerImplementation<InferDefaultType<T>>} */ (
         terserMinify
       ),
-      terserOptions = /** @type {InferDefault<T>} */ ({}),
+      terserOptions = /** @type {InferDefaultType<T>} */ ({}),
       test = /\.[cm]?js(\?.*)?$/i,
       extractComments = true,
       parallel = true,

--- a/src/minify.js
+++ b/src/minify.js
@@ -1,4 +1,5 @@
 /** @typedef {import("./index.js").MinimizedResult} MinimizedResult */
+/** @typedef {import("./index.js").CustomOptions} CustomOptions */
 
 /**
  * @template T

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,10 +6,7 @@ export type WebpackError = import("webpack").WebpackError;
 export type Asset = import("webpack").Asset;
 export type TerserECMA = import("./utils.js").TerserECMA;
 export type TerserOptions = import("./utils.js").TerserOptions;
-export type UglifyJSOptions = import("./utils.js").UglifyJSOptions;
-export type SwcOptions = import("./utils.js").SwcOptions;
-export type EsbuildOptions = import("./utils.js").EsbuildOptions;
-export type CustomOptions = any;
+export type CustomOptions = import("./utils.js").CustomOptions;
 export type JestWorker = import("jest-worker").Worker;
 export type RawSourceMap = import("source-map").RawSourceMap;
 export type Rule = RegExp | string;
@@ -55,11 +52,11 @@ export type MinimizedResult = {
 };
 export type PredefinedOptions = {
   module?: boolean | undefined;
-  ecma?: string | number | undefined;
+  ecma?: any;
 };
 export type MinimizerImplementationAndOptions<T> = {
-  implementation: MinimizerImplementation<ThirdArgument<T>>;
-  options: PredefinedOptions & ThirdArgument<T>;
+  implementation: MinimizerImplementation<T>;
+  options: PredefinedOptions & T;
 };
 export type InternalOptions<T> = {
   name: string;
@@ -83,11 +80,6 @@ export type MinimizeFunctionHelpers = {
 };
 export type MinimizerImplementation<T> = BasicMinimizerImplementation<T> &
   MinimizeFunctionHelpers;
-export type TerserMinimizer = MinimizerImplementation<TerserOptions>;
-export type UglifyJSMinimizer = MinimizerImplementation<UglifyJSOptions>;
-export type SwcMinimizer = MinimizerImplementation<SwcOptions>;
-export type EsbuildMinimizer = MinimizerImplementation<EsbuildOptions>;
-export type CustomMinimizer = MinimizerImplementation<CustomOptions>;
 export type BasePluginOptions = {
   test?: Rules | undefined;
   include?: Rules | undefined;
@@ -95,25 +87,13 @@ export type BasePluginOptions = {
   extractComments?: ExtractCommentsOptions | undefined;
   parallel?: boolean | undefined;
 };
-export type ThirdArgument<T> = T extends (
-  arg1: any,
-  arg2: any,
-  arg3: infer U,
-  ...args: any[]
-) => any
+export type InferDefault<T> = T extends infer U
   ? U
-  : never;
-export type DefaultMinimizerImplementationAndOptions<T> = {
-  minify?: undefined | MinimizerImplementation<ThirdArgument<T>>;
-  terserOptions?: ThirdArgument<T> | undefined;
+  : import("./utils").CustomOptions;
+export type DefinedDefaultMinimizerAndOptions<T> = {
+  minify?: MinimizerImplementation<InferDefault<T>> | undefined;
+  terserOptions?: InferDefault<T> | undefined;
 };
-export type PickMinimizerImplementationAndOptions<T> =
-  T extends MinimizerImplementation<TerserOptions>
-    ? DefaultMinimizerImplementationAndOptions<T>
-    : {
-        minify: MinimizerImplementation<ThirdArgument<T>>;
-        terserOptions?: ThirdArgument<T> | undefined;
-      };
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
 /** @typedef {import("webpack").Compilation} Compilation */
@@ -121,10 +101,7 @@ export type PickMinimizerImplementationAndOptions<T> =
 /** @typedef {import("webpack").Asset} Asset */
 /** @typedef {import("./utils.js").TerserECMA} TerserECMA */
 /** @typedef {import("./utils.js").TerserOptions} TerserOptions */
-/** @typedef {import("./utils.js").UglifyJSOptions} UglifyJSOptions */
-/** @typedef {import("./utils.js").SwcOptions} SwcOptions */
-/** @typedef {import("./utils.js").EsbuildOptions} EsbuildOptions */
-/** @typedef {Object.<any, any>} CustomOptions */
+/** @typedef {import("./utils.js").CustomOptions} CustomOptions */
 /** @typedef {import("jest-worker").Worker} JestWorker */
 /** @typedef {import("source-map").RawSourceMap} RawSourceMap */
 /** @typedef {RegExp | string} Rule */
@@ -167,13 +144,13 @@ export type PickMinimizerImplementationAndOptions<T> =
 /**
  * @typedef {Object} PredefinedOptions
  * @property {boolean} [module]
- * @property {5 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020 | number | string} [ecma]
+ * @property {any} [ecma]
  */
 /**
  * @template T
  * @typedef {Object} MinimizerImplementationAndOptions
- * @property {MinimizerImplementation<ThirdArgument<T>>} implementation
- * @property {PredefinedOptions & ThirdArgument<T>} options
+ * @property {MinimizerImplementation<T>} implementation
+ * @property {PredefinedOptions & T} options
  */
 /**
  * @template T
@@ -206,21 +183,6 @@ export type PickMinimizerImplementationAndOptions<T> =
  * @typedef {BasicMinimizerImplementation<T> & MinimizeFunctionHelpers } MinimizerImplementation
  */
 /**
- * @typedef {MinimizerImplementation<TerserOptions>} TerserMinimizer
- */
-/**
- * @typedef {MinimizerImplementation<UglifyJSOptions>} UglifyJSMinimizer
- */
-/**
- * @typedef {MinimizerImplementation<SwcOptions>} SwcMinimizer
- */
-/**
- * @typedef {MinimizerImplementation<EsbuildOptions>} EsbuildMinimizer
- */
-/**
- * @typedef {MinimizerImplementation<CustomOptions>} CustomMinimizer
- */
-/**
  * @typedef {Object} BasePluginOptions
  * @property {Rules} [test]
  * @property {Rules} [include]
@@ -230,29 +192,16 @@ export type PickMinimizerImplementationAndOptions<T> =
  */
 /**
  * @template T
- * @typedef {T extends (arg1: any, arg2: any, arg3: infer U, ...args: any[]) => any ? U: never} ThirdArgument
+ * @typedef {T extends infer U ? U : CustomOptions} InferDefault
  */
 /**
  * @template T
- * @typedef {Object} DefaultMinimizerImplementationAndOptions
- * @property {undefined | MinimizerImplementation<ThirdArgument<T>>} [minify]
- * @property {ThirdArgument<T> | undefined} [terserOptions]
+ * @typedef {{ minify?: MinimizerImplementation<InferDefault<T>> | undefined, terserOptions?: InferDefault<T> | undefined}} DefinedDefaultMinimizerAndOptions
  */
 /**
  * @template T
- * @typedef {T extends MinimizerImplementation<TerserOptions> ? DefaultMinimizerImplementationAndOptions<T> : { minify: MinimizerImplementation<ThirdArgument<T>>, terserOptions?: ThirdArgument<T> | undefined}} PickMinimizerImplementationAndOptions
  */
-/**
- * @template {TerserMinimizer | UglifyJSMinimizer | SwcMinimizer | EsbuildMinimizer | CustomMinimizer} T=TerserMinimizer
- */
-declare class TerserPlugin<
-  T extends
-    | TerserMinimizer
-    | UglifyJSMinimizer
-    | SwcMinimizer
-    | EsbuildMinimizer
-    | CustomMinimizer = TerserMinimizer
-> {
+declare class TerserPlugin<T = TerserOptions> {
   /**
    * @private
    * @param {any} input
@@ -288,19 +237,23 @@ declare class TerserPlugin<
    */
   private static getEcmaVersion;
   /**
-   * @param {BasePluginOptions & PickMinimizerImplementationAndOptions<T>} [options]
+   * @param {BasePluginOptions & DefinedDefaultMinimizerAndOptions<T>} [options]
    */
   constructor(
     options?:
-      | (BasePluginOptions & PickMinimizerImplementationAndOptions<T>)
+      | (BasePluginOptions & DefinedDefaultMinimizerAndOptions<T>)
       | undefined
   );
-  /**
-   * @type {BasePluginOptions & { minify: MinimizerImplementation<ThirdArgument<T>>, terserOptions: ThirdArgument<T>}}
-   */
-  options: BasePluginOptions & {
-    minify: MinimizerImplementation<ThirdArgument<T>>;
-    terserOptions: ThirdArgument<T>;
+  options: {
+    test: Rules;
+    extractComments: ExtractCommentsOptions;
+    parallel: boolean;
+    include: Rules | undefined;
+    exclude: Rules | undefined;
+    minimizer: {
+      implementation: MinimizerImplementation<InferDefault<T>>;
+      options: InferDefault<T>;
+    };
   };
   /**
    * @private

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -90,10 +90,16 @@ export type BasePluginOptions = {
 export type InferDefault<T> = T extends infer U
   ? U
   : import("./utils").CustomOptions;
-export type DefinedDefaultMinimizerAndOptions<T> = {
-  minify?: MinimizerImplementation<InferDefault<T>> | undefined;
-  terserOptions?: InferDefault<T> | undefined;
-};
+export type DefinedDefaultMinimizerAndOptions<T> =
+  InferDefault<T> extends TerserOptions
+    ? {
+        minify?: MinimizerImplementation<InferDefault<T>> | undefined;
+        terserOptions?: InferDefault<T> | undefined;
+      }
+    : {
+        minify: MinimizerImplementation<InferDefault<T>>;
+        terserOptions?: InferDefault<T> | undefined;
+      };
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
 /** @typedef {import("webpack").Compilation} Compilation */
@@ -196,7 +202,7 @@ export type DefinedDefaultMinimizerAndOptions<T> = {
  */
 /**
  * @template T
- * @typedef {{ minify?: MinimizerImplementation<InferDefault<T>> | undefined, terserOptions?: InferDefault<T> | undefined}} DefinedDefaultMinimizerAndOptions
+ * @typedef {InferDefault<T> extends TerserOptions ? { minify?: MinimizerImplementation<InferDefault<T>> | undefined, terserOptions?: InferDefault<T> | undefined } : { minify: MinimizerImplementation<InferDefault<T>>, terserOptions?: InferDefault<T> | undefined }} DefinedDefaultMinimizerAndOptions
  */
 /**
  * @template T
@@ -251,7 +257,9 @@ declare class TerserPlugin<T = TerserOptions> {
     include: Rules | undefined;
     exclude: Rules | undefined;
     minimizer: {
-      implementation: MinimizerImplementation<InferDefault<T>>;
+      implementation: MinimizerImplementation<
+        import("terser").MinifyOptions & InferDefault<T>
+      >;
       options: InferDefault<T>;
     };
   };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -87,18 +87,18 @@ export type BasePluginOptions = {
   extractComments?: ExtractCommentsOptions | undefined;
   parallel?: boolean | undefined;
 };
-export type InferDefault<T> = T extends infer U
+export type InferDefaultType<T> = T extends infer U
   ? U
   : import("./utils").CustomOptions;
 export type DefinedDefaultMinimizerAndOptions<T> =
-  InferDefault<T> extends TerserOptions
+  InferDefaultType<T> extends TerserOptions
     ? {
-        minify?: MinimizerImplementation<InferDefault<T>> | undefined;
-        terserOptions?: InferDefault<T> | undefined;
+        minify?: MinimizerImplementation<InferDefaultType<T>> | undefined;
+        terserOptions?: InferDefaultType<T> | undefined;
       }
     : {
-        minify: MinimizerImplementation<InferDefault<T>>;
-        terserOptions?: InferDefault<T> | undefined;
+        minify: MinimizerImplementation<InferDefaultType<T>>;
+        terserOptions?: InferDefaultType<T> | undefined;
       };
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
@@ -198,11 +198,11 @@ export type DefinedDefaultMinimizerAndOptions<T> =
  */
 /**
  * @template T
- * @typedef {T extends infer U ? U : CustomOptions} InferDefault
+ * @typedef {T extends infer U ? U : CustomOptions} InferDefaultType
  */
 /**
  * @template T
- * @typedef {InferDefault<T> extends TerserOptions ? { minify?: MinimizerImplementation<InferDefault<T>> | undefined, terserOptions?: InferDefault<T> | undefined } : { minify: MinimizerImplementation<InferDefault<T>>, terserOptions?: InferDefault<T> | undefined }} DefinedDefaultMinimizerAndOptions
+ * @typedef {InferDefaultType<T> extends TerserOptions ? { minify?: MinimizerImplementation<InferDefaultType<T>> | undefined, terserOptions?: InferDefaultType<T> | undefined } : { minify: MinimizerImplementation<InferDefaultType<T>>, terserOptions?: InferDefaultType<T> | undefined }} DefinedDefaultMinimizerAndOptions
  */
 /**
  * @template T
@@ -258,9 +258,9 @@ declare class TerserPlugin<T = TerserOptions> {
     exclude: Rules | undefined;
     minimizer: {
       implementation: MinimizerImplementation<
-        import("terser").MinifyOptions & InferDefault<T>
+        import("terser").MinifyOptions & InferDefaultType<T>
       >;
-      options: InferDefault<T>;
+      options: InferDefaultType<T>;
     };
   };
   /**

--- a/types/minify.d.ts
+++ b/types/minify.d.ts
@@ -1,5 +1,7 @@
 export type MinimizedResult = import("./index.js").MinimizedResult;
+export type CustomOptions = import("./index.js").CustomOptions;
 /** @typedef {import("./index.js").MinimizedResult} MinimizedResult */
+/** @typedef {import("./index.js").CustomOptions} CustomOptions */
 /**
  * @template T
  * @param {import("./index.js").InternalOptions<T>} options

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -2,14 +2,6 @@ export type RawSourceMap = import("source-map").RawSourceMap;
 export type TerserFormatOptions = import("terser").FormatOptions;
 export type TerserOptions = import("terser").MinifyOptions;
 export type TerserECMA = import("terser").ECMA;
-// @ts-ignore
-export type UglifyJSOutputOptions = import("uglify-js").OutputOptions;
-// @ts-ignore
-export type UglifyJSOptions = import("uglify-js").MinifyOptions;
-// @ts-ignore
-export type SwcOptions = import("@swc/core").JsMinifyOptions;
-// @ts-ignore
-export type EsbuildOptions = import("esbuild").TransformOptions;
 export type ExtractCommentsOptions =
   import("./index.js").ExtractCommentsOptions;
 export type ExtractCommentsFunction =
@@ -19,39 +11,14 @@ export type ExtractCommentsCondition =
 export type Input = import("./index.js").Input;
 export type MinimizedResult = import("./index.js").MinimizedResult;
 export type PredefinedOptions = import("./index.js").PredefinedOptions;
-export type NormalizedTerserOptions = TerserOptions & {
-  sourceMap: undefined;
-} & (
-    | {
-        output: TerserFormatOptions & {
-          beautify: boolean;
-        };
-      }
-    | {
-        format: TerserFormatOptions & {
-          beautify: boolean;
-        };
-      }
-  );
-export type NormalizedUglifyJSOptions = UglifyJSOptions & {
-  sourceMap: undefined;
-} & {
-  output: UglifyJSOutputOptions & {
-    beautify: boolean;
-  };
-};
-export type NormalizedSwcOptions = SwcOptions & {
-  sourceMap: undefined;
+export type CustomOptions = {
+  [key: string]: any;
 };
 export type ExtractedComments = Array<string>;
 /** @typedef {import("source-map").RawSourceMap} RawSourceMap */
 /** @typedef {import("terser").FormatOptions} TerserFormatOptions */
 /** @typedef {import("terser").MinifyOptions} TerserOptions */
 /** @typedef {import("terser").ECMA} TerserECMA */
-/** @typedef {import("uglify-js").OutputOptions} UglifyJSOutputOptions */
-/** @typedef {import("uglify-js").MinifyOptions} UglifyJSOptions */
-/** @typedef {import("@swc/core").JsMinifyOptions} SwcOptions */
-/** @typedef {import("esbuild").TransformOptions} EsbuildOptions */
 /** @typedef {import("./index.js").ExtractCommentsOptions} ExtractCommentsOptions */
 /** @typedef {import("./index.js").ExtractCommentsFunction} ExtractCommentsFunction */
 /** @typedef {import("./index.js").ExtractCommentsCondition} ExtractCommentsCondition */
@@ -59,13 +26,7 @@ export type ExtractedComments = Array<string>;
 /** @typedef {import("./index.js").MinimizedResult} MinimizedResult */
 /** @typedef {import("./index.js").PredefinedOptions} PredefinedOptions */
 /**
- * @typedef {TerserOptions & { sourceMap: undefined } & ({ output: TerserFormatOptions & { beautify: boolean } } | { format: TerserFormatOptions & { beautify: boolean } })} NormalizedTerserOptions
- */
-/**
- * @typedef {UglifyJSOptions & { sourceMap: undefined } & { output: UglifyJSOutputOptions & { beautify: boolean } }} NormalizedUglifyJSOptions
- */
-/**
- * @typedef {SwcOptions & { sourceMap: undefined }} NormalizedSwcOptions
+ * @typedef {{ [key: string]: any }} CustomOptions
  */
 /**
  * @typedef {Array<string>} ExtractedComments
@@ -73,14 +34,14 @@ export type ExtractedComments = Array<string>;
 /**
  * @param {Input} input
  * @param {RawSourceMap | undefined} sourceMap
- * @param {PredefinedOptions & TerserOptions} minimizerOptions
+ * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @param {ExtractCommentsOptions | undefined} extractComments
  * @return {Promise<MinimizedResult>}
  */
 export function terserMinify(
   input: Input,
   sourceMap: RawSourceMap | undefined,
-  minimizerOptions: PredefinedOptions & TerserOptions,
+  minimizerOptions: PredefinedOptions & CustomOptions,
   extractComments: ExtractCommentsOptions | undefined
 ): Promise<MinimizedResult>;
 export namespace terserMinify {
@@ -92,14 +53,14 @@ export namespace terserMinify {
 /**
  * @param {Input} input
  * @param {RawSourceMap | undefined} sourceMap
- * @param {PredefinedOptions & UglifyJSOptions} minimizerOptions
+ * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @param {ExtractCommentsOptions | undefined} extractComments
  * @return {Promise<MinimizedResult>}
  */
 export function uglifyJsMinify(
   input: Input,
   sourceMap: RawSourceMap | undefined,
-  minimizerOptions: PredefinedOptions & UglifyJSOptions,
+  minimizerOptions: PredefinedOptions & CustomOptions,
   extractComments: ExtractCommentsOptions | undefined
 ): Promise<MinimizedResult>;
 export namespace uglifyJsMinify {
@@ -111,13 +72,13 @@ export namespace uglifyJsMinify {
 /**
  * @param {Input} input
  * @param {RawSourceMap | undefined} sourceMap
- * @param {PredefinedOptions & SwcOptions} minimizerOptions
+ * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @return {Promise<MinimizedResult>}
  */
 export function swcMinify(
   input: Input,
   sourceMap: RawSourceMap | undefined,
-  minimizerOptions: PredefinedOptions & SwcOptions
+  minimizerOptions: PredefinedOptions & CustomOptions
 ): Promise<MinimizedResult>;
 export namespace swcMinify {
   /**
@@ -128,13 +89,13 @@ export namespace swcMinify {
 /**
  * @param {Input} input
  * @param {RawSourceMap | undefined} sourceMap
- * @param {PredefinedOptions & EsbuildOptions} minimizerOptions
+ * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @return {Promise<MinimizedResult>}
  */
 export function esbuildMinify(
   input: Input,
   sourceMap: RawSourceMap | undefined,
-  minimizerOptions: PredefinedOptions & EsbuildOptions
+  minimizerOptions: PredefinedOptions & CustomOptions
 ): Promise<MinimizedResult>;
 export namespace esbuildMinify {
   /**


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

fixes #439

### Breaking Changes

Potential yes, because some types were removed, but they were removed due invalid usage of optional peer dependencies, to fix it we should ast developers provide options for usage , here updated examples https://github.com/webpack-contrib/terser-webpack-plugin#typescript

### Additional Info

No