### PR TITLE
feat: remove cjs wrapper and improve types format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "typescript": "^4.3.5",
         "uglify-js": "^3.14.1",
         "webpack": "^5.48.0",
+        "webpack-cli": "^4.9.1",
         "worker-loader": "^3.0.8"
       },
       "engines": {
@@ -2154,6 +2155,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
+      "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
@@ -3610,6 +3620,42 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@webpack-cli/configtest": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+      "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x",
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/info": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+      "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+      "dev": true,
+      "dependencies": {
+        "envinfo": "^7.7.3"
+      },
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/serve": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+      "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@webpack-contrib/eslint-config-webpack": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@webpack-contrib/eslint-config-webpack/-/eslint-config-webpack-3.0.0.tgz",
@@ -4382,6 +4428,20 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -5506,6 +5566,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/envinfo": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+      "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+      "dev": true,
+      "bin": {
+        "envinfo": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -6543,6 +6615,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
+      "dev": true
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -7401,6 +7479,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -7598,6 +7685,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -7721,6 +7820,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -11250,6 +11358,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.9.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -11568,6 +11688,18 @@
       "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shebang-command": {
@@ -12740,6 +12872,77 @@
         }
       }
     },
+    "node_modules/webpack-cli": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
+      "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+      "dev": true,
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^1.1.0",
+        "@webpack-cli/info": "^1.4.0",
+        "@webpack-cli/serve": "^1.6.0",
+        "colorette": "^2.0.14",
+        "commander": "^7.0.0",
+        "execa": "^5.0.0",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^2.2.0",
+        "rechoir": "^0.7.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@webpack-cli/generators": {
+          "optional": true
+        },
+        "@webpack-cli/migrate": {
+          "optional": true
+        },
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli/node_modules/colorette": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+      "dev": true
+    },
+    "node_modules/webpack-cli/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-merge": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+      "dev": true,
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.2.tgz",
@@ -12808,6 +13011,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+      "dev": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -14511,6 +14720,12 @@
         }
       }
     },
+    "@discoveryjs/json-ext": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
+      "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
+      "dev": true
+    },
     "@endemolshinegroup/cosmiconfig-typescript-loader": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
@@ -15635,6 +15850,29 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@webpack-cli/configtest": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+      "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+      "dev": true,
+      "requires": {}
+    },
+    "@webpack-cli/info": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+      "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+      "dev": true,
+      "requires": {
+        "envinfo": "^7.7.3"
+      }
+    },
+    "@webpack-cli/serve": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+      "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+      "dev": true,
+      "requires": {}
+    },
     "@webpack-contrib/eslint-config-webpack": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@webpack-contrib/eslint-config-webpack/-/eslint-config-webpack-3.0.0.tgz",
@@ -16218,6 +16456,17 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
       }
     },
     "co": {
@@ -17081,6 +17330,12 @@
         "ansi-colors": "^4.1.1"
       }
     },
+    "envinfo": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+      "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+      "dev": true
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -17825,6 +18080,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
+      "dev": true
+    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -18464,6 +18725,12 @@
         "side-channel": "^1.0.4"
       }
     },
+    "interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "dev": true
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -18595,6 +18862,15 @@
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -18681,6 +18957,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -21321,6 +21603,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.9.0"
+      }
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -21561,6 +21852,15 @@
       "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "requires": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
       }
     },
     "shebang-command": {
@@ -22449,6 +22749,50 @@
         "webpack-sources": "^3.2.2"
       }
     },
+    "webpack-cli": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
+      "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+      "dev": true,
+      "requires": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^1.1.0",
+        "@webpack-cli/info": "^1.4.0",
+        "@webpack-cli/serve": "^1.6.0",
+        "colorette": "^2.0.14",
+        "commander": "^7.0.0",
+        "execa": "^5.0.0",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^2.2.0",
+        "rechoir": "^0.7.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "2.0.16",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+          "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+          "dev": true
+        },
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "dev": true
+        }
+      }
+    },
+    "webpack-merge": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+      "dev": true,
+      "requires": {
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
+      }
+    },
     "webpack-sources": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.2.tgz",
@@ -22502,6 +22846,12 @@
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
       }
+    },
+    "wildcard": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+      "dev": true
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
     "type": "opencollective",
     "url": "https://opencollective.com/webpack"
   },
-  "main": "dist/cjs.js",
-  "types": "types/cjs.d.ts",
+  "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">= 10.13.0"
   },
   "scripts": {
     "clean": "del-cli dist types",
     "prebuild": "npm run clean",
-    "build:types": "tsc --declaration --emitDeclarationOnly --outDir types && prettier \"types/**/*.ts\" --write && prettier types --write",
+    "build:types": "tsc --declaration --emitDeclarationOnly --outDir types && prettier \"types/**/*.ts\" --write",
     "build:code": "cross-env NODE_ENV=production babel src -d dist --copy-files",
     "build": "npm-run-all -p \"build:**\"",
     "commitlint": "commitlint --from=master",
@@ -91,6 +91,7 @@
     "typescript": "^4.3.5",
     "uglify-js": "^3.14.1",
     "webpack": "^5.48.0",
+    "webpack-cli": "^4.9.1",
     "worker-loader": "^3.0.8"
   },
   "keywords": [

--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,3 +1,0 @@
-const plugin = require("./index");
-
-module.exports = plugin.default;

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,21 @@
-import * as path from "path";
-import * as os from "os";
+const path = require("path");
+const os = require("os");
 
-import { SourceMapConsumer } from "source-map";
-import { validate } from "schema-utils";
-import serialize from "serialize-javascript";
-import { Worker } from "jest-worker";
+const { SourceMapConsumer } = require("source-map");
+const { validate } = require("schema-utils");
+const serialize = require("serialize-javascript");
+const { Worker } = require("jest-worker");
 
-import {
+const {
   throttleAll,
   terserMinify,
   uglifyJsMinify,
   swcMinify,
   esbuildMinify,
-} from "./utils";
+} = require("./utils");
 
-import * as schema from "./options.json";
-import { minify as minimize } from "./minify";
+const schema = require("./options.json");
+const { minify } = require("./minify");
 
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
@@ -495,7 +495,7 @@ class TerserPlugin {
           try {
             output = await (getWorker
               ? getWorker().transform(serialize(options))
-              : minimize(options));
+              : minify(options));
           } catch (error) {
             const hasSourceMap =
               inputSourceMap && TerserPlugin.isSourceMap(inputSourceMap);
@@ -866,4 +866,4 @@ TerserPlugin.uglifyJsMinify = uglifyJsMinify;
 TerserPlugin.swcMinify = swcMinify;
 TerserPlugin.esbuildMinify = esbuildMinify;
 
-export default TerserPlugin;
+module.exports = TerserPlugin;

--- a/src/minify.js
+++ b/src/minify.js
@@ -46,5 +46,4 @@ async function transform(options) {
   return minify(evaluatedOptions);
 }
 
-module.exports.minify = minify;
-module.exports.transform = transform;
+module.exports = { minify, transform };

--- a/src/utils.js
+++ b/src/utils.js
@@ -720,4 +720,10 @@ esbuildMinify.getMinimizerVersion = () => {
   return packageJson && packageJson.version;
 };
 
-export { throttleAll, terserMinify, uglifyJsMinify, swcMinify, esbuildMinify };
+module.exports = {
+  throttleAll,
+  terserMinify,
+  uglifyJsMinify,
+  swcMinify,
+  esbuildMinify,
+};

--- a/test/cjs.test.js
+++ b/test/cjs.test.js
@@ -1,8 +1,0 @@
-import src from "../src";
-import cjs from "../src/cjs";
-
-describe("CJS", () => {
-  it("should export loader", () => {
-    expect(cjs).toEqual(src);
-  });
-});

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -1,3 +1,0 @@
-declare const _exports: typeof plugin.default;
-export = _exports;
-import plugin = require("./index");

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,111 +1,4 @@
-export default TerserPlugin;
-export type Schema = import("schema-utils/declarations/validate").Schema;
-export type Compiler = import("webpack").Compiler;
-export type Compilation = import("webpack").Compilation;
-export type WebpackError = import("webpack").WebpackError;
-export type Asset = import("webpack").Asset;
-export type TerserECMA = import("./utils.js").TerserECMA;
-export type TerserOptions = import("./utils.js").TerserOptions;
-export type JestWorker = import("jest-worker").Worker;
-export type RawSourceMap = import("source-map").RawSourceMap;
-export type Rule = RegExp | string;
-export type Rules = Rule[] | Rule;
-export type ExtractCommentsFunction = (
-  astNode: any,
-  comment: {
-    value: string;
-    type: "comment1" | "comment2" | "comment3" | "comment4";
-    pos: number;
-    line: number;
-    col: number;
-  }
-) => boolean;
-export type ExtractCommentsCondition =
-  | boolean
-  | "all"
-  | "some"
-  | RegExp
-  | ExtractCommentsFunction;
-export type ExtractCommentsFilename = string | ((fileData: any) => string);
-export type ExtractCommentsBanner =
-  | string
-  | boolean
-  | ((commentsFile: string) => string);
-export type ExtractCommentsObject = {
-  condition?: ExtractCommentsCondition | undefined;
-  filename?: ExtractCommentsFilename | undefined;
-  banner?: ExtractCommentsBanner | undefined;
-};
-export type ExtractCommentsOptions =
-  | ExtractCommentsCondition
-  | ExtractCommentsObject;
-export type MinimizedResult = {
-  code: string;
-  map?: import("source-map").RawSourceMap | undefined;
-  errors?: (string | Error)[] | undefined;
-  warnings?: (string | Error)[] | undefined;
-  extractedComments?: string[] | undefined;
-};
-export type Input = {
-  [file: string]: string;
-};
-export type CustomOptions = {
-  [key: string]: any;
-};
-export type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
-export type PredefinedOptions = {
-  module?: boolean | undefined;
-  ecma?: any;
-};
-export type MinimizerOptions<T> = PredefinedOptions & InferDefaultType<T>;
-export type BasicMinimizerImplementation<T> = (
-  input: Input,
-  sourceMap: RawSourceMap | undefined,
-  minifyOptions: MinimizerOptions<T>,
-  extractComments: ExtractCommentsOptions | undefined
-) => Promise<MinimizedResult>;
-export type MinimizeFunctionHelpers = {
-  getMinimizerVersion?: (() => string | undefined) | undefined;
-};
-export type MinimizerImplementation<T> = BasicMinimizerImplementation<T> &
-  MinimizeFunctionHelpers;
-export type InternalOptions<T> = {
-  name: string;
-  input: string;
-  inputSourceMap: RawSourceMap | undefined;
-  extractComments: ExtractCommentsOptions | undefined;
-  minimizer: {
-    implementation: MinimizerImplementation<T>;
-    options: MinimizerOptions<T>;
-  };
-};
-export type MinimizerWorker<T> = Worker & {
-  transform: (options: string) => MinimizedResult;
-  minify: (options: InternalOptions<T>) => MinimizedResult;
-};
-export type Parallel = undefined | boolean | number;
-export type BasePluginOptions = {
-  test?: Rules | undefined;
-  include?: Rules | undefined;
-  exclude?: Rules | undefined;
-  extractComments?: ExtractCommentsOptions | undefined;
-  parallel?: Parallel;
-};
-export type DefinedDefaultMinimizerAndOptions<T> = T extends TerserOptions
-  ? {
-      minify?: MinimizerImplementation<T> | undefined;
-      terserOptions?: MinimizerOptions<T> | undefined;
-    }
-  : {
-      minify: MinimizerImplementation<T>;
-      terserOptions?: MinimizerOptions<T> | undefined;
-    };
-export type InternalPluginOptions<T> = BasePluginOptions & {
-  minimizer: {
-    implementation: MinimizerImplementation<T>;
-    options: MinimizerOptions<T>;
-  };
-};
+export = TerserPlugin;
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
 /** @typedef {import("webpack").Compilation} Compilation */
@@ -284,13 +177,153 @@ declare class TerserPlugin<T = import("terser").MinifyOptions> {
   apply(compiler: Compiler): void;
 }
 declare namespace TerserPlugin {
-  export { terserMinify };
-  export { uglifyJsMinify };
-  export { swcMinify };
-  export { esbuildMinify };
+  export {
+    terserMinify,
+    uglifyJsMinify,
+    swcMinify,
+    esbuildMinify,
+    Schema,
+    Compiler,
+    Compilation,
+    WebpackError,
+    Asset,
+    TerserECMA,
+    TerserOptions,
+    JestWorker,
+    RawSourceMap,
+    Rule,
+    Rules,
+    ExtractCommentsFunction,
+    ExtractCommentsCondition,
+    ExtractCommentsFilename,
+    ExtractCommentsBanner,
+    ExtractCommentsObject,
+    ExtractCommentsOptions,
+    MinimizedResult,
+    Input,
+    CustomOptions,
+    InferDefaultType,
+    PredefinedOptions,
+    MinimizerOptions,
+    BasicMinimizerImplementation,
+    MinimizeFunctionHelpers,
+    MinimizerImplementation,
+    InternalOptions,
+    MinimizerWorker,
+    Parallel,
+    BasePluginOptions,
+    DefinedDefaultMinimizerAndOptions,
+    InternalPluginOptions,
+  };
 }
-import { Worker } from "jest-worker";
+type Compiler = import("webpack").Compiler;
+type BasePluginOptions = {
+  test?: Rules | undefined;
+  include?: Rules | undefined;
+  exclude?: Rules | undefined;
+  extractComments?: ExtractCommentsOptions | undefined;
+  parallel?: Parallel;
+};
+type DefinedDefaultMinimizerAndOptions<T> = T extends TerserOptions
+  ? {
+      minify?: MinimizerImplementation<T> | undefined;
+      terserOptions?: MinimizerOptions<T> | undefined;
+    }
+  : {
+      minify: MinimizerImplementation<T>;
+      terserOptions?: MinimizerOptions<T> | undefined;
+    };
 import { terserMinify } from "./utils";
 import { uglifyJsMinify } from "./utils";
 import { swcMinify } from "./utils";
 import { esbuildMinify } from "./utils";
+type Schema = import("schema-utils/declarations/validate").Schema;
+type Compilation = import("webpack").Compilation;
+type WebpackError = import("webpack").WebpackError;
+type Asset = import("webpack").Asset;
+type TerserECMA = import("./utils.js").TerserECMA;
+type TerserOptions = import("./utils.js").TerserOptions;
+type JestWorker = import("jest-worker").Worker;
+type RawSourceMap = import("source-map").RawSourceMap;
+type Rule = RegExp | string;
+type Rules = Rule[] | Rule;
+type ExtractCommentsFunction = (
+  astNode: any,
+  comment: {
+    value: string;
+    type: "comment1" | "comment2" | "comment3" | "comment4";
+    pos: number;
+    line: number;
+    col: number;
+  }
+) => boolean;
+type ExtractCommentsCondition =
+  | boolean
+  | "all"
+  | "some"
+  | RegExp
+  | ExtractCommentsFunction;
+type ExtractCommentsFilename = string | ((fileData: any) => string);
+type ExtractCommentsBanner =
+  | string
+  | boolean
+  | ((commentsFile: string) => string);
+type ExtractCommentsObject = {
+  condition?: ExtractCommentsCondition | undefined;
+  filename?: ExtractCommentsFilename | undefined;
+  banner?: ExtractCommentsBanner | undefined;
+};
+type ExtractCommentsOptions = ExtractCommentsCondition | ExtractCommentsObject;
+type MinimizedResult = {
+  code: string;
+  map?: import("source-map").RawSourceMap | undefined;
+  errors?: (string | Error)[] | undefined;
+  warnings?: (string | Error)[] | undefined;
+  extractedComments?: string[] | undefined;
+};
+type Input = {
+  [file: string]: string;
+};
+type CustomOptions = {
+  [key: string]: any;
+};
+type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
+type PredefinedOptions = {
+  module?: boolean | undefined;
+  ecma?: any;
+};
+type MinimizerOptions<T> = PredefinedOptions & InferDefaultType<T>;
+type BasicMinimizerImplementation<T> = (
+  input: Input,
+  sourceMap: RawSourceMap | undefined,
+  minifyOptions: MinimizerOptions<T>,
+  extractComments: ExtractCommentsOptions | undefined
+) => Promise<MinimizedResult>;
+type MinimizeFunctionHelpers = {
+  getMinimizerVersion?: (() => string | undefined) | undefined;
+};
+type MinimizerImplementation<T> = BasicMinimizerImplementation<T> &
+  MinimizeFunctionHelpers;
+type InternalOptions<T> = {
+  name: string;
+  input: string;
+  inputSourceMap: RawSourceMap | undefined;
+  extractComments: ExtractCommentsOptions | undefined;
+  minimizer: {
+    implementation: MinimizerImplementation<T>;
+    options: MinimizerOptions<T>;
+  };
+};
+type MinimizerWorker<T> = Worker & {
+  transform: (options: string) => MinimizedResult;
+  minify: (options: InternalOptions<T>) => MinimizedResult;
+};
+type Parallel = undefined | boolean | number;
+type InternalPluginOptions<T> = BasePluginOptions & {
+  minimizer: {
+    implementation: MinimizerImplementation<T>;
+    options: MinimizerOptions<T>;
+  };
+};
+import { minify } from "./minify";
+import { Worker } from "jest-worker";


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

removed cjs wrapper and generated types in commonjs format (`export =` and `namespaces` used in types), now you can directly use exported types

### Breaking Changes

Potentially yes, but we use `babel` and our code in commonjs format, but typescript generate ESM format for declarations, it is bug

### Additional Info

No