### PR TITLE
perf: replace source-map package with @jridgewell/trace-mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ type minify = (
   input: {
     [file: string]: string;
   },
-  sourceMap: import("source-map").RawSourceMap | undefined,
+  sourceMap: import("@jridgewell/trace-mapping").SourceMapInput | undefined,
   minifyOptions: {
     module?: boolean | undefined;
     ecma?: import("terser").ECMA | undefined;
@@ -267,7 +267,7 @@ type minify = (
     | undefined
 ) => Promise<{
   code: string;
-  map?: import("source-map").RawSourceMap | undefined;
+  map?: import("@jridgewell/trace-mapping").SourceMapInput | undefined;
   errors?: (string | Error)[] | undefined;
   warnings?: (string | Error)[] | undefined;
   extractedComments?: string[] | undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "5.3.1",
       "license": "MIT",
       "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.7",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "source-map": "^0.6.1",
         "terser": "^5.7.2"
       },
       "devDependencies": {
@@ -2976,6 +2976,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
+      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
@@ -15308,6 +15330,25 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA=="
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
+      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "@nicolo-ribaudo/chokidar-2": {

--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
     }
   },
   "dependencies": {
+    "@jridgewell/trace-mapping": "^0.3.7",
     "jest-worker": "^27.4.5",
     "schema-utils": "^3.1.1",
     "serialize-javascript": "^6.0.0",
-    "source-map": "^0.6.1",
     "terser": "^5.7.2"
   },
   "devDependencies": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-/** @typedef {import("source-map").RawSourceMap} RawSourceMap */
+/** @typedef {import("@jridgewell/trace-mapping").SourceMapInput} SourceMapInput */
 /** @typedef {import("terser").FormatOptions} TerserFormatOptions */
 /** @typedef {import("terser").MinifyOptions} TerserOptions */
 /** @typedef {import("terser").ECMA} TerserECMA */
@@ -80,7 +80,7 @@ function throttleAll(limit, tasks) {
 /* istanbul ignore next */
 /**
  * @param {Input} input
- * @param {RawSourceMap | undefined} sourceMap
+ * @param {SourceMapInput | undefined} sourceMap
  * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @param {ExtractCommentsOptions | undefined} extractComments
  * @return {Promise<MinimizedResult>}
@@ -287,7 +287,7 @@ async function terserMinify(
     code: /** @type {string} **/ (result.code),
     // @ts-ignore
     // eslint-disable-next-line no-undefined
-    map: result.map ? /** @type {RawSourceMap} **/ (result.map) : undefined,
+    map: result.map ? /** @type {SourceMapInput} **/ (result.map) : undefined,
     extractedComments,
   };
 }
@@ -311,7 +311,7 @@ terserMinify.getMinimizerVersion = () => {
 /* istanbul ignore next */
 /**
  * @param {Input} input
- * @param {RawSourceMap | undefined} sourceMap
+ * @param {SourceMapInput | undefined} sourceMap
  * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @param {ExtractCommentsOptions | undefined} extractComments
  * @return {Promise<MinimizedResult>}
@@ -529,7 +529,7 @@ uglifyJsMinify.getMinimizerVersion = () => {
 /* istanbul ignore next */
 /**
  * @param {Input} input
- * @param {RawSourceMap | undefined} sourceMap
+ * @param {SourceMapInput | undefined} sourceMap
  * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @return {Promise<MinimizedResult>}
  */
@@ -613,7 +613,7 @@ swcMinify.getMinimizerVersion = () => {
 /* istanbul ignore next */
 /**
  * @param {Input} input
- * @param {RawSourceMap | undefined} sourceMap
+ * @param {SourceMapInput | undefined} sourceMap
  * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @return {Promise<MinimizedResult>}
  */

--- a/test/TerserPlugin.test.js
+++ b/test/TerserPlugin.test.js
@@ -2,7 +2,7 @@ import crypto from "crypto";
 
 import path from "path";
 
-import { SourceMapConsumer } from "source-map";
+import { TraceMap } from "@jridgewell/trace-mapping";
 import CopyWebpackPlugin from "copy-webpack-plugin";
 import RequestShortener from "webpack/lib/RequestShortener";
 import { javascript, SourceMapDevToolPlugin, util } from "webpack";
@@ -551,7 +551,7 @@ describe("TerserPlugin", () => {
       TerserPlugin.buildError(
         errorWithLineAndCol,
         "test.js",
-        new SourceMapConsumer(rawSourceMap),
+        new TraceMap(rawSourceMap),
         // eslint-disable-next-line no-undefined
         undefined
       )
@@ -567,7 +567,7 @@ describe("TerserPlugin", () => {
       TerserPlugin.buildError(
         otherErrorWithLineAndCol,
         "test.js",
-        new SourceMapConsumer(rawSourceMap),
+        new TraceMap(rawSourceMap),
         new RequestShortener("/example.com/www/js/")
       )
     ).toMatchSnapshot();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,7 @@ export = TerserPlugin;
 /** @typedef {import("./utils.js").TerserECMA} TerserECMA */
 /** @typedef {import("./utils.js").TerserOptions} TerserOptions */
 /** @typedef {import("jest-worker").Worker} JestWorker */
-/** @typedef {import("source-map").RawSourceMap} RawSourceMap */
+/** @typedef {import("@jridgewell/trace-mapping").SourceMapInput} SourceMapInput */
 /** @typedef {RegExp | string} Rule */
 /** @typedef {Rule[] | Rule} Rules */
 /**
@@ -37,7 +37,7 @@ export = TerserPlugin;
 /**
  * @typedef {Object} MinimizedResult
  * @property {string} code
- * @property {RawSourceMap} [map]
+ * @property {SourceMapInput} [map]
  * @property {Array<Error | string>} [errors]
  * @property {Array<Error | string>} [warnings]
  * @property {Array<string>} [extractedComments]
@@ -65,7 +65,7 @@ export = TerserPlugin;
  * @template T
  * @callback BasicMinimizerImplementation
  * @param {Input} input
- * @param {RawSourceMap | undefined} sourceMap
+ * @param {SourceMapInput | undefined} sourceMap
  * @param {MinimizerOptions<T>} minifyOptions
  * @param {ExtractCommentsOptions | undefined} extractComments
  * @returns {Promise<MinimizedResult>}
@@ -83,7 +83,7 @@ export = TerserPlugin;
  * @typedef {Object} InternalOptions
  * @property {string} name
  * @property {string} input
- * @property {RawSourceMap | undefined} inputSourceMap
+ * @property {SourceMapInput | undefined} inputSourceMap
  * @property {ExtractCommentsOptions | undefined} extractComments
  * @property {{ implementation: MinimizerImplementation<T>, options: MinimizerOptions<T> }} minimizer
  */
@@ -131,7 +131,7 @@ declare class TerserPlugin<T = import("terser").MinifyOptions> {
    * @private
    * @param {any} error
    * @param {string} file
-   * @param {SourceMapConsumer} [sourceMap]
+   * @param {TraceMap} [sourceMap]
    * @param {Compilation["requestShortener"]} [requestShortener]
    * @returns {Error}
    */
@@ -190,7 +190,7 @@ declare namespace TerserPlugin {
     TerserECMA,
     TerserOptions,
     JestWorker,
-    RawSourceMap,
+    SourceMapInput,
     Rule,
     Rules,
     ExtractCommentsFunction,
@@ -244,7 +244,7 @@ type Asset = import("webpack").Asset;
 type TerserECMA = import("./utils.js").TerserECMA;
 type TerserOptions = import("./utils.js").TerserOptions;
 type JestWorker = import("jest-worker").Worker;
-type RawSourceMap = import("source-map").RawSourceMap;
+type SourceMapInput = import("@jridgewell/trace-mapping").SourceMapInput;
 type Rule = RegExp | string;
 type Rules = Rule[] | Rule;
 type ExtractCommentsFunction = (
@@ -276,7 +276,7 @@ type ExtractCommentsObject = {
 type ExtractCommentsOptions = ExtractCommentsCondition | ExtractCommentsObject;
 type MinimizedResult = {
   code: string;
-  map?: import("source-map").RawSourceMap | undefined;
+  map?: import("@jridgewell/trace-mapping").SourceMapInput | undefined;
   errors?: (string | Error)[] | undefined;
   warnings?: (string | Error)[] | undefined;
   extractedComments?: string[] | undefined;
@@ -295,7 +295,7 @@ type PredefinedOptions = {
 type MinimizerOptions<T> = PredefinedOptions & InferDefaultType<T>;
 type BasicMinimizerImplementation<T> = (
   input: Input,
-  sourceMap: RawSourceMap | undefined,
+  sourceMap: SourceMapInput | undefined,
   minifyOptions: MinimizerOptions<T>,
   extractComments: ExtractCommentsOptions | undefined
 ) => Promise<MinimizedResult>;
@@ -307,7 +307,7 @@ type MinimizerImplementation<T> = BasicMinimizerImplementation<T> &
 type InternalOptions<T> = {
   name: string;
   input: string;
-  inputSourceMap: RawSourceMap | undefined;
+  inputSourceMap: SourceMapInput | undefined;
   extractComments: ExtractCommentsOptions | undefined;
   minimizer: {
     implementation: MinimizerImplementation<T>;

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -1,5 +1,5 @@
 export type Task<T> = () => Promise<T>;
-export type RawSourceMap = import("source-map").RawSourceMap;
+export type SourceMapInput = import("@jridgewell/trace-mapping").SourceMapInput;
 export type TerserFormatOptions = import("terser").FormatOptions;
 export type TerserOptions = import("terser").MinifyOptions;
 export type TerserECMA = import("terser").ECMA;
@@ -28,14 +28,14 @@ export type ExtractedComments = Array<string>;
 export function throttleAll<T>(limit: number, tasks: Task<T>[]): Promise<T[]>;
 /**
  * @param {Input} input
- * @param {RawSourceMap | undefined} sourceMap
+ * @param {SourceMapInput | undefined} sourceMap
  * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @param {ExtractCommentsOptions | undefined} extractComments
  * @return {Promise<MinimizedResult>}
  */
 export function terserMinify(
   input: Input,
-  sourceMap: RawSourceMap | undefined,
+  sourceMap: SourceMapInput | undefined,
   minimizerOptions: PredefinedOptions & CustomOptions,
   extractComments: ExtractCommentsOptions | undefined
 ): Promise<MinimizedResult>;
@@ -47,14 +47,14 @@ export namespace terserMinify {
 }
 /**
  * @param {Input} input
- * @param {RawSourceMap | undefined} sourceMap
+ * @param {SourceMapInput | undefined} sourceMap
  * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @param {ExtractCommentsOptions | undefined} extractComments
  * @return {Promise<MinimizedResult>}
  */
 export function uglifyJsMinify(
   input: Input,
-  sourceMap: RawSourceMap | undefined,
+  sourceMap: SourceMapInput | undefined,
   minimizerOptions: PredefinedOptions & CustomOptions,
   extractComments: ExtractCommentsOptions | undefined
 ): Promise<MinimizedResult>;
@@ -66,13 +66,13 @@ export namespace uglifyJsMinify {
 }
 /**
  * @param {Input} input
- * @param {RawSourceMap | undefined} sourceMap
+ * @param {SourceMapInput | undefined} sourceMap
  * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @return {Promise<MinimizedResult>}
  */
 export function swcMinify(
   input: Input,
-  sourceMap: RawSourceMap | undefined,
+  sourceMap: SourceMapInput | undefined,
   minimizerOptions: PredefinedOptions & CustomOptions
 ): Promise<MinimizedResult>;
 export namespace swcMinify {
@@ -83,13 +83,13 @@ export namespace swcMinify {
 }
 /**
  * @param {Input} input
- * @param {RawSourceMap | undefined} sourceMap
+ * @param {SourceMapInput | undefined} sourceMap
  * @param {PredefinedOptions & CustomOptions} minimizerOptions
  * @return {Promise<MinimizedResult>}
  */
 export function esbuildMinify(
   input: Input,
-  sourceMap: RawSourceMap | undefined,
+  sourceMap: SourceMapInput | undefined,
   minimizerOptions: PredefinedOptions & CustomOptions
 ): Promise<MinimizedResult>;
 export namespace esbuildMinify {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The trace-mapping module is faster than source-map in every benchmark
https://github.com/jridgewell/trace-mapping#benchmarks

It's also being adopted by many packages across the ecosystem ([Jest](https://github.com/facebook/jest/pull/12692), [Babel](https://github.com/babel/babel/blob/main/CHANGELOG.md#v71710-2022-04-29), [Terser](https://github.com/terser/terser/blob/master/CHANGELOG.md#v5140) at least have included it already)
And it doesn't need to be async like `source-map` 0.7.*

A previous PR to upgrade for `source-map` 0.7 was refused in the past : https://github.com/webpack-contrib/terser-webpack-plugin/pull/280

### Breaking Changes

None

### Additional Info
