### PR TITLE
fix(swc/esbuild): allows minifiers to set worker thread support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,7 @@ const { minify } = require("./minify");
 /**
  * @typedef {object} MinimizeFunctionHelpers
  * @property {() => string | undefined} [getMinimizerVersion]
+ * @property {() => boolean | undefined} [supportsWorkerThreads]
  */
 
 /**
@@ -412,7 +413,12 @@ class TerserPlugin {
           (
             new Worker(require.resolve("./minify"), {
               numWorkers: numberOfWorkers,
-              enableWorkerThreads: true,
+              enableWorkerThreads:
+                typeof this.options.minimizer.implementation
+                  .supportsWorkerThreads !== "undefined"
+                  ? this.options.minimizer.implementation.supportsWorkerThreads() !==
+                    false
+                  : true,
             })
           );
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -326,6 +326,11 @@ terserMinify.getMinimizerVersion = () => {
   return packageJson && packageJson.version;
 };
 
+/**
+ * @returns {boolean | undefined}
+ */
+terserMinify.supportsWorkerThreads = () => true;
+
 /* istanbul ignore next */
 /**
  * @param {Input} input
@@ -544,6 +549,11 @@ uglifyJsMinify.getMinimizerVersion = () => {
   return packageJson && packageJson.version;
 };
 
+/**
+ * @returns {boolean | undefined}
+ */
+uglifyJsMinify.supportsWorkerThreads = () => true;
+
 /* istanbul ignore next */
 /**
  * @param {Input} input
@@ -644,6 +654,11 @@ swcMinify.getMinimizerVersion = () => {
 
   return packageJson && packageJson.version;
 };
+
+/**
+ * @returns {boolean | undefined}
+ */
+swcMinify.supportsWorkerThreads = () => false;
 
 /* istanbul ignore next */
 /**
@@ -754,6 +769,11 @@ esbuildMinify.getMinimizerVersion = () => {
 
   return packageJson && packageJson.version;
 };
+
+/**
+ * @returns {boolean | undefined}
+ */
+esbuildMinify.supportsWorkerThreads = () => false;
 
 /**
  * @template T

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -192,6 +192,7 @@ type BasicMinimizerImplementation<T> = (
 ) => Promise<MinimizedResult>;
 type MinimizeFunctionHelpers = {
   getMinimizerVersion?: (() => string | undefined) | undefined;
+  supportsWorkerThreads?: (() => boolean | undefined) | undefined;
 };
 type MinimizerImplementation<T> = BasicMinimizerImplementation<T> &
   MinimizeFunctionHelpers;

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -51,6 +51,10 @@ export namespace terserMinify {
    * @returns {string | undefined}
    */
   function getMinimizerVersion(): string | undefined;
+  /**
+   * @returns {boolean | undefined}
+   */
+  function supportsWorkerThreads(): boolean | undefined;
 }
 /**
  * @param {Input} input
@@ -70,6 +74,10 @@ export namespace uglifyJsMinify {
    * @returns {string | undefined}
    */
   function getMinimizerVersion(): string | undefined;
+  /**
+   * @returns {boolean | undefined}
+   */
+  function supportsWorkerThreads(): boolean | undefined;
 }
 /**
  * @param {Input} input
@@ -87,6 +95,10 @@ export namespace swcMinify {
    * @returns {string | undefined}
    */
   function getMinimizerVersion(): string | undefined;
+  /**
+   * @returns {boolean | undefined}
+   */
+  function supportsWorkerThreads(): boolean | undefined;
 }
 /**
  * @param {Input} input
@@ -104,4 +116,8 @@ export namespace esbuildMinify {
    * @returns {string | undefined}
    */
   function getMinimizerVersion(): string | undefined;
+  /**
+   * @returns {boolean | undefined}
+   */
+  function supportsWorkerThreads(): boolean | undefined;
 }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Worker threads are actually problematic for SWC/esbuild because of thread locals.

Closes #580

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

Replaces #616