### PR TITLE
fix: use `os.availableParallelism()` for parallelism when it is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ type parallel = boolean | number;
 Default: `true`
 
 Use multi-process parallel running to improve the build speed.
-Default number of concurrent runs: `os.cpus().length - 1`.
+Default number of concurrent runs: `os.cpus().length - 1` or `os.availableParallelism() - 1` (if this function is supported).
 
 > **Note**
 >

--- a/src/index.js
+++ b/src/index.js
@@ -325,7 +325,7 @@ class TerserPlugin {
         ? { length: os.availableParallelism() }
         : os.cpus() || { length: 1 };
 
-    return parallel === true
+    return parallel === true || typeof parallel === "undefined"
       ? cpus.length - 1
       : Math.min(parallel || 0, cpus.length - 1);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -320,11 +320,14 @@ class TerserPlugin {
   static getAvailableNumberOfCores(parallel) {
     // In some cases cpus() returns undefined
     // https://github.com/nodejs/node/issues/19022
-    const cpus = os.cpus() || { length: 1 };
+    const cpus =
+      typeof os.availableParallelism === "function"
+        ? { length: os.availableParallelism() }
+        : os.cpus() || { length: 1 };
 
     return parallel === true
       ? cpus.length - 1
-      : Math.min(Number(parallel) || 0, cpus.length - 1);
+      : Math.min(parallel || 0, cpus.length - 1);
   }
 
   /**

--- a/test/__snapshots__/parallel-option.test.js.snap
+++ b/test/__snapshots__/parallel-option.test.js.snap
@@ -90,6 +90,19 @@ exports[`parallel option should match snapshot for the "true" value: errors 1`] 
 
 exports[`parallel option should match snapshot for the "true" value: warnings 1`] = `Array []`;
 
+exports[`parallel option should match snapshot for the "undefined" value: assets 1`] = `
+Object {
+  "four.js": "(()=>{var r={921:r=>{r.exports=function(){console.log(7)}}},o={};(function t(e){var n=o[e];if(void 0!==n)return n.exports;var s=o[e]={exports:{}};return r[e](s,s.exports,t),s.exports})(921)})();",
+  "one.js": "(()=>{var r={921:r=>{r.exports=function(){console.log(7)}}},o={};(function t(e){var n=o[e];if(void 0!==n)return n.exports;var s=o[e]={exports:{}};return r[e](s,s.exports,t),s.exports})(921)})();",
+  "three.js": "(()=>{var r={921:r=>{r.exports=function(){console.log(7)}}},o={};(function t(e){var n=o[e];if(void 0!==n)return n.exports;var s=o[e]={exports:{}};return r[e](s,s.exports,t),s.exports})(921)})();",
+  "two.js": "(()=>{var r={921:r=>{r.exports=function(){console.log(7)}}},o={};(function t(e){var n=o[e];if(void 0!==n)return n.exports;var s=o[e]={exports:{}};return r[e](s,s.exports,t),s.exports})(921)})();",
+}
+`;
+
+exports[`parallel option should match snapshot for the "undefined" value: errors 1`] = `Array []`;
+
+exports[`parallel option should match snapshot for the "undefined" value: warnings 1`] = `Array []`;
+
 exports[`parallel option should match snapshot when a value is not specify: assets 1`] = `
 Object {
   "four.js": "(()=>{var r={921:r=>{r.exports=function(){console.log(7)}}},o={};(function t(e){var n=o[e];if(void 0!==n)return n.exports;var s=o[e]={exports:{}};return r[e](s,s.exports,t),s.exports})(921)})();",


### PR DESCRIPTION
…able

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Use `os.availableParallelism()` when it is available 

### Breaking Changes

No

### Additional Info

No